### PR TITLE
feat: pass through Context

### DIFF
--- a/internal/controllers/budget_controller.go
+++ b/internal/controllers/budget_controller.go
@@ -30,6 +30,8 @@ type createBudgetRequest struct {
 
 // CreateBudget adds a new budget
 func (bc *BudgetController) CreateBudget(c *gin.Context) {
+	ctx := c.Request.Context()
+
 	userID, ok := currentUserID(c)
 	if !ok {
 		return
@@ -49,7 +51,7 @@ func (bc *BudgetController) CreateBudget(c *gin.Context) {
 		EndDate:    req.EndDate,
 	}
 
-	if err := bc.budgetService.CreateBudget(&budget); err != nil {
+	if err := bc.budgetService.CreateBudget(ctx, &budget); err != nil {
 		httpapi.WriteError(c, err)
 		return
 	}
@@ -59,12 +61,14 @@ func (bc *BudgetController) CreateBudget(c *gin.Context) {
 
 // GetBudgets fetches all budgets for a user
 func (bc *BudgetController) GetBudgets(c *gin.Context) {
+	ctx := c.Request.Context()
+
 	userID, ok := currentUserID(c)
 	if !ok {
 		return
 	}
 
-	budgets, err := bc.budgetService.GetBudgetsByUser(userID)
+	budgets, err := bc.budgetService.GetBudgetsByUser(ctx, userID)
 	if err != nil {
 		httpapi.WriteError(c, err)
 		return
@@ -75,6 +79,8 @@ func (bc *BudgetController) GetBudgets(c *gin.Context) {
 
 // DeleteBudget removes a budget
 func (bc *BudgetController) DeleteBudget(c *gin.Context) {
+	ctx := c.Request.Context()
+
 	userID, ok := currentUserID(c)
 	if !ok {
 		return
@@ -86,7 +92,7 @@ func (bc *BudgetController) DeleteBudget(c *gin.Context) {
 		return
 	}
 
-	if err := bc.budgetService.DeleteBudgetForUser(userID, uint(budgetID)); err != nil {
+	if err := bc.budgetService.DeleteBudgetForUser(ctx, userID, uint(budgetID)); err != nil {
 		httpapi.WriteError(c, err)
 		return
 	}

--- a/internal/controllers/budget_controller_test.go
+++ b/internal/controllers/budget_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -20,23 +21,23 @@ type MockBudgetService struct {
 	mock.Mock
 }
 
-func (m *MockBudgetService) CreateBudget(budget *models.Budget) error {
-	args := m.Called(budget)
+func (m *MockBudgetService) CreateBudget(ctx context.Context, budget *models.Budget) error {
+	args := m.Called(ctx, budget)
 	return args.Error(0)
 }
 
-func (m *MockBudgetService) GetBudgetsByUser(userID uint) ([]models.Budget, error) {
-	args := m.Called(userID)
+func (m *MockBudgetService) GetBudgetsByUser(ctx context.Context, userID uint) ([]models.Budget, error) {
+	args := m.Called(ctx, userID)
 	return args.Get(0).([]models.Budget), args.Error(1)
 }
 
-func (m *MockBudgetService) DeleteBudgetForUser(userID, budgetID uint) error {
-	args := m.Called(userID, budgetID)
+func (m *MockBudgetService) DeleteBudgetForUser(ctx context.Context, userID, budgetID uint) error {
+	args := m.Called(ctx, userID, budgetID)
 	return args.Error(0)
 }
 
-func (m *MockBudgetService) UpdateBudget(budget *models.Budget) error {
-	args := m.Called(budget)
+func (m *MockBudgetService) UpdateBudget(ctx context.Context, budget *models.Budget) error {
+	args := m.Called(ctx, budget)
 	return args.Error(0)
 }
 
@@ -56,7 +57,7 @@ func TestCreateBudget(t *testing.T) {
 			"end_date":    endDate.Format(time.RFC3339),
 		}
 
-		mockService.On("CreateBudget", mock.MatchedBy(func(b *models.Budget) bool {
+		mockService.On("CreateBudget", mock.Anything, mock.MatchedBy(func(b *models.Budget) bool {
 			return b.UserID == 1 &&
 				b.CategoryID == 2 &&
 				b.Limit == 1000 &&
@@ -91,7 +92,7 @@ func TestCreateBudget(t *testing.T) {
 			"end_date":    now.AddDate(0, 1, 0).Format(time.RFC3339),
 		}
 
-		mockService.On("CreateBudget", mock.AnythingOfType("*models.Budget")).
+		mockService.On("CreateBudget", mock.Anything, mock.AnythingOfType("*models.Budget")).
 			Return(apperrors.Validation("invalid_budget_limit", "budget limit must be greater than zero")).Once()
 
 		w := httptest.NewRecorder()
@@ -123,7 +124,7 @@ func TestCreateBudget(t *testing.T) {
 			"end_date":    endDate.Format(time.RFC3339),
 		}
 
-		mockService.On("CreateBudget", mock.AnythingOfType("*models.Budget")).
+		mockService.On("CreateBudget", mock.Anything, mock.AnythingOfType("*models.Budget")).
 			Return(apperrors.Validation("invalid_budget_date_range", "start date cannot be after end date")).Once()
 
 		w := httptest.NewRecorder()
@@ -175,7 +176,7 @@ func TestGetBudgets(t *testing.T) {
 			{UserID: 1, CategoryID: 3, Limit: 500, StartDate: now, EndDate: now.AddDate(0, 2, 0)},
 		}
 
-		mockService.On("GetBudgetsByUser", uint(1)).Return(expectedBudgets, nil).Once()
+		mockService.On("GetBudgetsByUser", mock.Anything, uint(1)).Return(expectedBudgets, nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -195,7 +196,7 @@ func TestGetBudgets(t *testing.T) {
 		mockService := new(MockBudgetService)
 		controller := NewBudgetController(mockService)
 
-		mockService.On("GetBudgetsByUser", uint(1)).
+		mockService.On("GetBudgetsByUser", mock.Anything, uint(1)).
 			Return([]models.Budget(nil), apperrors.Internal("budgets_fetch_failed", "failed to retrieve budgets", nil)).Once()
 
 		w := httptest.NewRecorder()
@@ -218,7 +219,7 @@ func TestDeleteBudget(t *testing.T) {
 		mockService := new(MockBudgetService)
 		controller := NewBudgetController(mockService)
 
-		mockService.On("DeleteBudgetForUser", uint(1), uint(1)).Return(nil).Once()
+		mockService.On("DeleteBudgetForUser", mock.Anything, uint(1), uint(1)).Return(nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -253,7 +254,7 @@ func TestDeleteBudget(t *testing.T) {
 		mockService := new(MockBudgetService)
 		controller := NewBudgetController(mockService)
 
-		mockService.On("DeleteBudgetForUser", uint(1), uint(1)).
+		mockService.On("DeleteBudgetForUser", mock.Anything, uint(1), uint(1)).
 			Return(apperrors.NotFound("budget_not_found", "budget not found")).Once()
 
 		w := httptest.NewRecorder()

--- a/internal/controllers/transaction_controller.go
+++ b/internal/controllers/transaction_controller.go
@@ -30,6 +30,8 @@ type createTransactionRequest struct {
 
 // CreateTransaction adds a new transaction
 func (tc *TransactionController) CreateTransaction(c *gin.Context) {
+	ctx := c.Request.Context()
+
 	userID, ok := currentUserID(c)
 	if !ok {
 		return
@@ -50,7 +52,7 @@ func (tc *TransactionController) CreateTransaction(c *gin.Context) {
 		Note:       req.Note,
 	}
 
-	err := tc.transactionService.AddTransaction(&transaction)
+	err := tc.transactionService.AddTransaction(ctx, &transaction)
 	if err != nil {
 		httpapi.WriteError(c, err)
 		return
@@ -61,12 +63,14 @@ func (tc *TransactionController) CreateTransaction(c *gin.Context) {
 
 // GetTransactions fetches all transactions for a user
 func (tc *TransactionController) GetTransactions(c *gin.Context) {
+	ctx := c.Request.Context()
+
 	userID, ok := currentUserID(c)
 	if !ok {
 		return
 	}
 
-	transactions, err := tc.transactionService.GetTransactionsByUser(userID)
+	transactions, err := tc.transactionService.GetTransactionsByUser(ctx, userID)
 	if err != nil {
 		httpapi.WriteError(c, err)
 		return
@@ -77,6 +81,8 @@ func (tc *TransactionController) GetTransactions(c *gin.Context) {
 
 // DeleteTransaction removes a transaction
 func (tc *TransactionController) DeleteTransaction(c *gin.Context) {
+	ctx := c.Request.Context()
+
 	userID, ok := currentUserID(c)
 	if !ok {
 		return
@@ -88,7 +94,7 @@ func (tc *TransactionController) DeleteTransaction(c *gin.Context) {
 		return
 	}
 
-	err = tc.transactionService.DeleteTransactionForUser(userID, uint(transactionID))
+	err = tc.transactionService.DeleteTransactionForUser(ctx, userID, uint(transactionID))
 	if err != nil {
 		httpapi.WriteError(c, err)
 		return

--- a/internal/controllers/transaction_controller_test.go
+++ b/internal/controllers/transaction_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -20,18 +21,18 @@ type MockTransactionService struct {
 	mock.Mock
 }
 
-func (m *MockTransactionService) AddTransaction(t *models.Transaction) error {
-	args := m.Called(t)
+func (m *MockTransactionService) AddTransaction(ctx context.Context, t *models.Transaction) error {
+	args := m.Called(ctx, t)
 	return args.Error(0)
 }
 
-func (m *MockTransactionService) GetTransactionsByUser(userID uint) ([]models.Transaction, error) {
-	args := m.Called(userID)
+func (m *MockTransactionService) GetTransactionsByUser(ctx context.Context, userID uint) ([]models.Transaction, error) {
+	args := m.Called(ctx, userID)
 	return args.Get(0).([]models.Transaction), args.Error(1)
 }
 
-func (m *MockTransactionService) DeleteTransactionForUser(userID, transactionID uint) error {
-	args := m.Called(userID, transactionID)
+func (m *MockTransactionService) DeleteTransactionForUser(ctx context.Context, userID, transactionID uint) error {
+	args := m.Called(ctx, userID, transactionID)
 	return args.Error(0)
 }
 
@@ -51,7 +52,7 @@ func TestCreateTransaction(t *testing.T) {
 			"note":        "Lunch",
 		}
 
-		mockService.On("AddTransaction", mock.MatchedBy(func(t *models.Transaction) bool {
+		mockService.On("AddTransaction", mock.Anything, mock.MatchedBy(func(t *models.Transaction) bool {
 			return t.UserID == 1 &&
 				t.Amount == 50.0 &&
 				t.CategoryID == 2 &&
@@ -87,7 +88,7 @@ func TestCreateTransaction(t *testing.T) {
 			"date":        now.Format(time.RFC3339),
 		}
 
-		mockService.On("AddTransaction", mock.AnythingOfType("*models.Transaction")).
+		mockService.On("AddTransaction", mock.Anything, mock.AnythingOfType("*models.Transaction")).
 			Return(apperrors.Validation("budget_limit_exceeded", "transaction exceeds budget limit")).Once()
 
 		w := httptest.NewRecorder()
@@ -139,7 +140,7 @@ func TestGetTransactions(t *testing.T) {
 			{UserID: 1, Amount: 100.0, CategoryID: 2, Type: "income", Date: now, Note: "Salary"},
 		}
 
-		mockService.On("GetTransactionsByUser", uint(1)).Return(transactions, nil).Once()
+		mockService.On("GetTransactionsByUser", mock.Anything, uint(1)).Return(transactions, nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -159,7 +160,7 @@ func TestGetTransactions(t *testing.T) {
 		mockService := new(MockTransactionService)
 		controller := NewTransactionController(mockService)
 
-		mockService.On("GetTransactionsByUser", uint(1)).
+		mockService.On("GetTransactionsByUser", mock.Anything, uint(1)).
 			Return([]models.Transaction(nil), apperrors.Internal("transactions_fetch_failed", "failed to retrieve transactions", nil)).Once()
 
 		w := httptest.NewRecorder()
@@ -182,7 +183,7 @@ func TestDeleteTransaction(t *testing.T) {
 		mockService := new(MockTransactionService)
 		controller := NewTransactionController(mockService)
 
-		mockService.On("DeleteTransactionForUser", uint(1), uint(1)).Return(nil).Once()
+		mockService.On("DeleteTransactionForUser", mock.Anything, uint(1), uint(1)).Return(nil).Once()
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
@@ -217,7 +218,7 @@ func TestDeleteTransaction(t *testing.T) {
 		mockService := new(MockTransactionService)
 		controller := NewTransactionController(mockService)
 
-		mockService.On("DeleteTransactionForUser", uint(1), uint(1)).
+		mockService.On("DeleteTransactionForUser", mock.Anything, uint(1), uint(1)).
 			Return(apperrors.NotFound("transaction_not_found", "transaction not found")).Once()
 
 		w := httptest.NewRecorder()

--- a/internal/controllers/user_controller.go
+++ b/internal/controllers/user_controller.go
@@ -39,6 +39,7 @@ func NewUserController(userService services.UserService, tokenManager auth.Token
 
 // Register handles user registration
 func (uc *UserController) Register(c *gin.Context) {
+	ctx := c.Request.Context()
 	var req registerRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -46,7 +47,7 @@ func (uc *UserController) Register(c *gin.Context) {
 		return
 	}
 
-	createdUser, err := uc.userService.RegisterUser(req.Name, req.Email, req.Password)
+	createdUser, err := uc.userService.RegisterUser(ctx, req.Name, req.Email, req.Password)
 	if err != nil {
 		httpapi.WriteError(c, err)
 		return
@@ -67,6 +68,7 @@ func (uc *UserController) Register(c *gin.Context) {
 
 // Login handles user authentication
 func (uc *UserController) Login(c *gin.Context) {
+	ctx := c.Request.Context()
 	var req loginRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -74,7 +76,7 @@ func (uc *UserController) Login(c *gin.Context) {
 		return
 	}
 
-	user, err := uc.userService.AuthenticateUser(req.Email, req.Password)
+	user, err := uc.userService.AuthenticateUser(ctx, req.Email, req.Password)
 	if err != nil {
 		httpapi.WriteError(c, err)
 		return

--- a/internal/controllers/user_controller_test.go
+++ b/internal/controllers/user_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -37,16 +38,16 @@ type MockUserService struct {
 	mock.Mock
 }
 
-func (m *MockUserService) RegisterUser(name, email, password string) (*models.User, error) {
-	args := m.Called(name, email, password)
+func (m *MockUserService) RegisterUser(ctx context.Context, name, email, password string) (*models.User, error) {
+	args := m.Called(ctx, name, email, password)
 	if args.Get(0) != nil {
 		return args.Get(0).(*models.User), args.Error(1)
 	}
 	return nil, args.Error(1)
 }
 
-func (m *MockUserService) AuthenticateUser(email, password string) (*models.User, error) {
-	args := m.Called(email, password)
+func (m *MockUserService) AuthenticateUser(ctx context.Context, email, password string) (*models.User, error) {
+	args := m.Called(ctx, email, password)
 	if args.Get(0) != nil {
 		return args.Get(0).(*models.User), args.Error(1)
 	}
@@ -72,7 +73,7 @@ func TestRegister(t *testing.T) {
 			Email: "alice@example.com",
 		}
 
-		mockService.On("RegisterUser", "Alice", "alice@example.com", "secure123").
+		mockService.On("RegisterUser", mock.Anything, "Alice", "alice@example.com", "secure123").
 			Return(expected, nil).Once()
 		mockTokenManager.On("GenerateToken", expected).Return("token-123", nil).Once()
 
@@ -122,7 +123,7 @@ func TestRegister(t *testing.T) {
 			"password": "password123",
 		}
 
-		mockService.On("RegisterUser", "Bob", "bob@example.com", "password123").
+		mockService.On("RegisterUser", mock.Anything, "Bob", "bob@example.com", "password123").
 			Return((*models.User)(nil), apperrors.Conflict("email_already_registered", "email already registered")).Once()
 
 		w := httptest.NewRecorder()
@@ -153,7 +154,7 @@ func TestLogin(t *testing.T) {
 		password := "secure123"
 		expected := &models.User{ID: 1, Name: "Alice", Email: email}
 
-		mockService.On("AuthenticateUser", email, password).
+		mockService.On("AuthenticateUser", mock.Anything, email, password).
 			Return(expected, nil).Once()
 		mockTokenManager.On("GenerateToken", expected).Return("token-abc", nil).Once()
 
@@ -205,7 +206,7 @@ func TestLogin(t *testing.T) {
 		email := "bob@example.com"
 		password := "wrongpass"
 
-		mockService.On("AuthenticateUser", email, password).
+		mockService.On("AuthenticateUser", mock.Anything, email, password).
 			Return((*models.User)(nil), apperrors.Unauthorized("invalid_credentials", "invalid credentials")).Once()
 
 		body := map[string]string{"email": email, "password": password}

--- a/internal/repositories/budget_repository.go
+++ b/internal/repositories/budget_repository.go
@@ -1,15 +1,17 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // BudgetRepository defines the required repository methods
 // This ensures other services can use different implementations if needed.
 type BudgetRepository interface {
-	CreateBudget(budget *models.Budget) error
-	GetBudgetByID(id uint) (*models.Budget, error)
-	GetBudgetsByUserID(userID uint) ([]models.Budget, error)
-	UpdateBudget(budget *models.Budget) error
-	DeleteBudget(id uint) error
+	CreateBudget(ctx context.Context, budget *models.Budget) error
+	GetBudgetByID(ctx context.Context, id uint) (*models.Budget, error)
+	GetBudgetsByUserID(ctx context.Context, userID uint) ([]models.Budget, error)
+	UpdateBudget(ctx context.Context, budget *models.Budget) error
+	DeleteBudget(ctx context.Context, id uint) error
 }

--- a/internal/repositories/category_repository.go
+++ b/internal/repositories/category_repository.go
@@ -1,14 +1,16 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // CategoryRepository defines required repository methods
 type CategoryRepository interface {
-	CreateCategory(category *models.Category) error
-	GetCategoryByID(id uint) (*models.Category, error)
-	GetAllCategories() ([]models.Category, error)
-	UpdateCategory(category *models.Category) error
-	DeleteCategory(id uint) error
+	CreateCategory(ctx context.Context, category *models.Category) error
+	GetCategoryByID(ctx context.Context, id uint) (*models.Category, error)
+	GetAllCategories(ctx context.Context) ([]models.Category, error)
+	UpdateCategory(ctx context.Context, category *models.Category) error
+	DeleteCategory(ctx context.Context, id uint) error
 }

--- a/internal/repositories/gorm/gorm_budget_repository.go
+++ b/internal/repositories/gorm/gorm_budget_repository.go
@@ -1,6 +1,8 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"gorm.io/gorm"
 )
@@ -8,11 +10,11 @@ import (
 // BudgetRepository defines the required repository methods
 // This ensures other services can use different implementations if needed.
 type BudgetRepository interface {
-	CreateBudget(budget *models.Budget) error
-	GetBudgetByID(id uint) (*models.Budget, error)
-	GetBudgetsByUserID(userID uint) ([]models.Budget, error)
-	UpdateBudget(budget *models.Budget) error
-	DeleteBudget(id uint) error
+	CreateBudget(ctx context.Context, budget *models.Budget) error
+	GetBudgetByID(ctx context.Context, id uint) (*models.Budget, error)
+	GetBudgetsByUserID(ctx context.Context, userID uint) ([]models.Budget, error)
+	UpdateBudget(ctx context.Context, budget *models.Budget) error
+	DeleteBudget(ctx context.Context, id uint) error
 }
 
 // GormBudgetRepository handles DB operations for budgets using GORM
@@ -26,14 +28,14 @@ func NewGormBudgetRepository(db *gorm.DB) *GormBudgetRepository {
 }
 
 // CreateBudget inserts a new budget into the database
-func (r *GormBudgetRepository) CreateBudget(budget *models.Budget) error {
-	return r.db.Create(budget).Error
+func (r *GormBudgetRepository) CreateBudget(ctx context.Context, budget *models.Budget) error {
+	return r.db.WithContext(ctx).Create(budget).Error
 }
 
 // GetBudgetByID retrieves a budget by its ID
-func (r *GormBudgetRepository) GetBudgetByID(id uint) (*models.Budget, error) {
+func (r *GormBudgetRepository) GetBudgetByID(ctx context.Context, id uint) (*models.Budget, error) {
 	var budget models.Budget
-	err := r.db.First(&budget, id).Error
+	err := r.db.WithContext(ctx).First(&budget, id).Error
 	if err != nil {
 		return nil, err
 	}
@@ -41,18 +43,18 @@ func (r *GormBudgetRepository) GetBudgetByID(id uint) (*models.Budget, error) {
 }
 
 // GetBudgetsByUserID fetches all budgets for a specific user
-func (r *GormBudgetRepository) GetBudgetsByUserID(userID uint) ([]models.Budget, error) {
+func (r *GormBudgetRepository) GetBudgetsByUserID(ctx context.Context, userID uint) ([]models.Budget, error) {
 	var budgets []models.Budget
-	err := r.db.Where("user_id = ?", userID).Find(&budgets).Error
+	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Find(&budgets).Error
 	return budgets, err
 }
 
 // UpdateBudget updates an existing budget
-func (r *GormBudgetRepository) UpdateBudget(budget *models.Budget) error {
-	return r.db.Save(budget).Error
+func (r *GormBudgetRepository) UpdateBudget(ctx context.Context, budget *models.Budget) error {
+	return r.db.WithContext(ctx).Save(budget).Error
 }
 
 // DeleteBudget removes a budget from the database
-func (r *GormBudgetRepository) DeleteBudget(id uint) error {
-	return r.db.Delete(&models.Budget{}, id).Error
+func (r *GormBudgetRepository) DeleteBudget(ctx context.Context, id uint) error {
+	return r.db.WithContext(ctx).Delete(&models.Budget{}, id).Error
 }

--- a/internal/repositories/gorm/gorm_budget_repository_test.go
+++ b/internal/repositories/gorm/gorm_budget_repository_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ func setupBudgetTestDB(t *testing.T) *gorm.DB {
 func TestCreateBudget(t *testing.T) {
 	db := setupBudgetTestDB(t)
 	repo := NewGormBudgetRepository(db)
+	ctx := context.Background()
 
 	t.Run("Create valid budget", func(t *testing.T) {
 		budget := &models.Budget{
@@ -33,7 +35,7 @@ func TestCreateBudget(t *testing.T) {
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
 
-		err := repo.CreateBudget(budget)
+		err := repo.CreateBudget(ctx, budget)
 		assert.NoError(t, err)
 
 		var retrievedBudget models.Budget
@@ -47,6 +49,7 @@ func TestCreateBudget(t *testing.T) {
 func TestGetBudgetByID(t *testing.T) {
 	db := setupBudgetTestDB(t)
 	repo := NewGormBudgetRepository(db)
+	ctx := context.Background()
 
 	t.Run("Retrieve existing budget", func(t *testing.T) {
 		budget := &models.Budget{
@@ -56,10 +59,10 @@ func TestGetBudgetByID(t *testing.T) {
 			StartDate:  time.Now(),
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
-		err := repo.CreateBudget(budget)
+		err := repo.CreateBudget(ctx, budget)
 		assert.NoError(t, err)
 
-		foundBudget, err := repo.GetBudgetByID(budget.ID)
+		foundBudget, err := repo.GetBudgetByID(ctx, budget.ID)
 		assert.NoError(t, err)
 		assert.NotNil(t, foundBudget)
 		assert.Equal(t, budget.Limit, foundBudget.Limit)
@@ -67,7 +70,7 @@ func TestGetBudgetByID(t *testing.T) {
 
 	t.Run("Retrieve non-existent budget", func(t *testing.T) {
 		nonExistentID := uint(9999)
-		budget, err := repo.GetBudgetByID(nonExistentID)
+		budget, err := repo.GetBudgetByID(ctx, nonExistentID)
 
 		assert.Error(t, err)
 		assert.Nil(t, budget)
@@ -79,6 +82,7 @@ func TestGetBudgetByID(t *testing.T) {
 func TestGetBudgetsByUserID(t *testing.T) {
 	db := setupBudgetTestDB(t)
 	repo := NewGormBudgetRepository(db)
+	ctx := context.Background()
 
 	// Ensure a clean state before running the test
 	db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&models.Budget{})
@@ -98,18 +102,18 @@ func TestGetBudgetsByUserID(t *testing.T) {
 			StartDate:  time.Now(),
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
-		err1 := repo.CreateBudget(budget1)
+		err1 := repo.CreateBudget(ctx, budget1)
 		assert.NoError(t, err1)
-		err2 := repo.CreateBudget(budget2)
+		err2 := repo.CreateBudget(ctx, budget2)
 		assert.NoError(t, err2)
 
-		budgets, err := repo.GetBudgetsByUserID(1)
+		budgets, err := repo.GetBudgetsByUserID(ctx, 1)
 		assert.NoError(t, err)
 		assert.Len(t, budgets, 2)
 	})
 
 	t.Run("User has no budgets", func(t *testing.T) {
-		budgets, err := repo.GetBudgetsByUserID(9999) // Non-existent user
+		budgets, err := repo.GetBudgetsByUserID(ctx, 9999) // Non-existent user
 		assert.NoError(t, err)
 		assert.Len(t, budgets, 0)
 	})
@@ -119,6 +123,7 @@ func TestGetBudgetsByUserID(t *testing.T) {
 func TestDeleteBudget(t *testing.T) {
 	db := setupBudgetTestDB(t)
 	repo := NewGormBudgetRepository(db)
+	ctx := context.Background()
 
 	t.Run("Delete existing budget", func(t *testing.T) {
 		budget := &models.Budget{
@@ -128,10 +133,10 @@ func TestDeleteBudget(t *testing.T) {
 			StartDate:  time.Now(),
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
-		err1 := repo.CreateBudget(budget)
+		err1 := repo.CreateBudget(ctx, budget)
 		assert.NoError(t, err1)
 
-		err := repo.DeleteBudget(budget.ID)
+		err := repo.DeleteBudget(ctx, budget.ID)
 		assert.NoError(t, err)
 
 		var deletedBudget models.Budget
@@ -145,6 +150,7 @@ func TestDeleteBudget(t *testing.T) {
 func TestUpdateBudget(t *testing.T) {
 	db := setupBudgetTestDB(t)
 	repo := NewGormBudgetRepository(db)
+	ctx := context.Background()
 
 	// Ensure related entities exist
 	user := &models.User{Name: "Test User", Email: "test@example.com", Password: "hashedpassword"}
@@ -161,12 +167,12 @@ func TestUpdateBudget(t *testing.T) {
 			StartDate:  time.Now(),
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
-		err1 := repo.CreateBudget(budget)
+		err1 := repo.CreateBudget(ctx, budget)
 		assert.NoError(t, err1)
 
 		// Update the budget
 		budget.Limit = 750.00
-		err := repo.UpdateBudget(budget)
+		err := repo.UpdateBudget(ctx, budget)
 		assert.NoError(t, err)
 
 		// Fetch updated budget

--- a/internal/repositories/gorm/gorm_category_repository.go
+++ b/internal/repositories/gorm/gorm_category_repository.go
@@ -1,17 +1,19 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"gorm.io/gorm"
 )
 
 // CategoryRepository defines required repository methods
 type CategoryRepository interface {
-	CreateCategory(category *models.Category) error
-	GetCategoryByID(id uint) (*models.Category, error)
-	GetAllCategories() ([]models.Category, error)
-	UpdateCategory(category *models.Category) error
-	DeleteCategory(id uint) error
+	CreateCategory(ctx context.Context, category *models.Category) error
+	GetCategoryByID(ctx context.Context, id uint) (*models.Category, error)
+	GetAllCategories(ctx context.Context) ([]models.Category, error)
+	UpdateCategory(ctx context.Context, category *models.Category) error
+	DeleteCategory(ctx context.Context, id uint) error
 }
 
 // CategoryRepository handles DB operations for categories
@@ -25,14 +27,14 @@ func NewCategoryRepository(db *gorm.DB) *GormCategoryRepository {
 }
 
 // CreateCategory inserts a new category into the database
-func (r *GormCategoryRepository) CreateCategory(category *models.Category) error {
-	return r.db.Create(category).Error
+func (r *GormCategoryRepository) CreateCategory(ctx context.Context, category *models.Category) error {
+	return r.db.WithContext(ctx).Create(category).Error
 }
 
 // GetCategoryByID retrieves a category by its ID
-func (r *GormCategoryRepository) GetCategoryByID(id uint) (*models.Category, error) {
+func (r *GormCategoryRepository) GetCategoryByID(ctx context.Context, id uint) (*models.Category, error) {
 	var category models.Category
-	err := r.db.First(&category, id).Error
+	err := r.db.WithContext(ctx).First(&category, id).Error
 	if err != nil {
 		return nil, err
 	}
@@ -40,18 +42,18 @@ func (r *GormCategoryRepository) GetCategoryByID(id uint) (*models.Category, err
 }
 
 // GetAllCategories fetches all categories
-func (r *GormCategoryRepository) GetAllCategories() ([]models.Category, error) {
+func (r *GormCategoryRepository) GetAllCategories(ctx context.Context) ([]models.Category, error) {
 	var categories []models.Category
-	err := r.db.Find(&categories).Error
+	err := r.db.WithContext(ctx).Find(&categories).Error
 	return categories, err
 }
 
 // UpdateCategory updates an existing category
-func (r *GormCategoryRepository) UpdateCategory(category *models.Category) error {
-	return r.db.Save(category).Error
+func (r *GormCategoryRepository) UpdateCategory(ctx context.Context, category *models.Category) error {
+	return r.db.WithContext(ctx).Save(category).Error
 }
 
 // DeleteCategory removes a category from the database
-func (r *GormCategoryRepository) DeleteCategory(id uint) error {
-	return r.db.Delete(&models.Category{}, id).Error
+func (r *GormCategoryRepository) DeleteCategory(ctx context.Context, id uint) error {
+	return r.db.WithContext(ctx).Delete(&models.Category{}, id).Error
 }

--- a/internal/repositories/gorm/gorm_category_repository_test.go
+++ b/internal/repositories/gorm/gorm_category_repository_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"testing"
 
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/database"
@@ -22,10 +23,11 @@ func setupCategoryTestDB(t *testing.T) *gorm.DB {
 func TestCreateCategory(t *testing.T) {
 	db := setupCategoryTestDB(t)
 	repo := NewCategoryRepository(db)
+	ctx := context.Background()
 
 	t.Run("Create valid category", func(t *testing.T) {
 		category := &models.Category{Name: "Groceries", Description: "Food and drinks"}
-		err := repo.CreateCategory(category)
+		err := repo.CreateCategory(ctx, category)
 		assert.NoError(t, err)
 
 		var retrievedCategory models.Category
@@ -38,10 +40,10 @@ func TestCreateCategory(t *testing.T) {
 		category1 := &models.Category{Name: "Health", Description: "Medical expenses"}
 		category2 := &models.Category{Name: "Health", Description: "Duplicate category"}
 
-		err := repo.CreateCategory(category1)
+		err := repo.CreateCategory(ctx, category1)
 		assert.NoError(t, err)
 
-		err = repo.CreateCategory(category2) // Should fail due to unique constraint
+		err = repo.CreateCategory(ctx, category2) // Should fail due to unique constraint
 		assert.Error(t, err)
 	})
 }
@@ -50,20 +52,21 @@ func TestCreateCategory(t *testing.T) {
 func TestGetCategoryByID(t *testing.T) {
 	db := setupCategoryTestDB(t)
 	repo := NewCategoryRepository(db)
+	ctx := context.Background()
 
 	t.Run("Retrieve existing category", func(t *testing.T) {
 		category := &models.Category{Name: "Utilities", Description: "Electricity, water, gas"}
-		err := repo.CreateCategory(category)
+		err := repo.CreateCategory(ctx, category)
 		assert.NoError(t, err)
 
-		foundCategory, err := repo.GetCategoryByID(category.ID)
+		foundCategory, err := repo.GetCategoryByID(ctx, category.ID)
 		assert.NoError(t, err)
 		assert.NotNil(t, foundCategory)
 		assert.Equal(t, category.Name, foundCategory.Name)
 	})
 
 	t.Run("Retrieve non-existent category", func(t *testing.T) {
-		category, err := repo.GetCategoryByID(9999) // Non-existent ID
+		category, err := repo.GetCategoryByID(ctx, 9999) // Non-existent ID
 		assert.Error(t, err)
 		assert.Nil(t, category)
 		assert.Equal(t, gorm.ErrRecordNotFound, err)
@@ -74,23 +77,24 @@ func TestGetCategoryByID(t *testing.T) {
 func TestGetAllCategories(t *testing.T) {
 	db := setupCategoryTestDB(t)
 	repo := NewCategoryRepository(db)
+	ctx := context.Background()
 
 	t.Run("Retrieve multiple categories", func(t *testing.T) {
 		category1 := &models.Category{Name: "Education", Description: "School and learning"}
 		category2 := &models.Category{Name: "Entertainment", Description: "Movies, concerts"}
-		err1 := repo.CreateCategory(category1)
+		err1 := repo.CreateCategory(ctx, category1)
 		assert.NoError(t, err1)
-		err2 := repo.CreateCategory(category2)
+		err2 := repo.CreateCategory(ctx, category2)
 		assert.NoError(t, err2)
 
-		categories, err := repo.GetAllCategories()
+		categories, err := repo.GetAllCategories(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, categories, 2)
 	})
 
 	t.Run("Retrieve categories when none exist", func(t *testing.T) {
 		db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&models.Category{}) // Ensure no data
-		categories, err := repo.GetAllCategories()
+		categories, err := repo.GetAllCategories(ctx)
 
 		assert.NoError(t, err)
 		assert.Len(t, categories, 0)
@@ -101,13 +105,14 @@ func TestGetAllCategories(t *testing.T) {
 func TestDeleteCategory(t *testing.T) {
 	db := setupCategoryTestDB(t)
 	repo := NewCategoryRepository(db)
+	ctx := context.Background()
 
 	t.Run("Delete existing category", func(t *testing.T) {
 		category := &models.Category{Name: "Gaming", Description: "Video games"}
-		err1 := repo.CreateCategory(category)
+		err1 := repo.CreateCategory(ctx, category)
 		assert.NoError(t, err1)
 
-		err := repo.DeleteCategory(category.ID)
+		err := repo.DeleteCategory(ctx, category.ID)
 		assert.NoError(t, err)
 
 		var deletedCategory models.Category
@@ -117,8 +122,8 @@ func TestDeleteCategory(t *testing.T) {
 	})
 
 	t.Run("Delete non-existent category", func(t *testing.T) {
-		err := repo.DeleteCategory(9999) // Non-existent ID
-		assert.NoError(t, err)           // `gorm.Delete` doesn't return an error if the record doesn't exist
+		err := repo.DeleteCategory(ctx, 9999) // Non-existent ID
+		assert.NoError(t, err)                // `gorm.Delete` doesn't return an error if the record doesn't exist
 	})
 }
 
@@ -126,17 +131,18 @@ func TestDeleteCategory(t *testing.T) {
 func TestUpdateCategory(t *testing.T) {
 	db := setupCategoryTestDB(t)
 	repo := NewCategoryRepository(db)
+	ctx := context.Background()
 
 	t.Run("Update existing category", func(t *testing.T) {
 		// Create a category
 		category := &models.Category{Name: "Transport", Description: "Car, public transport"}
-		err1 := repo.CreateCategory(category)
+		err1 := repo.CreateCategory(ctx, category)
 		assert.NoError(t, err1)
 
 		// Update the category
 		category.Name = "Travel"
 		category.Description = "Flights, hotels, and transport"
-		err := repo.UpdateCategory(category)
+		err := repo.UpdateCategory(ctx, category)
 		assert.NoError(t, err)
 
 		// Fetch updated category

--- a/internal/repositories/gorm/gorm_payment_method_repository.go
+++ b/internal/repositories/gorm/gorm_payment_method_repository.go
@@ -1,17 +1,19 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"gorm.io/gorm"
 )
 
 // PaymentMethodRepository defines the required repository methods
 type PaymentMethodRepository interface {
-	CreatePaymentMethod(paymentMethod *models.PaymentMethod) error
-	GetPaymentMethodByID(id uint) (*models.PaymentMethod, error)
-	GetPaymentMethodsByUserID(userID uint) ([]models.PaymentMethod, error)
-	UpdatePaymentMethod(paymentMethod *models.PaymentMethod) error
-	DeletePaymentMethod(id uint) error
+	CreatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error
+	GetPaymentMethodByID(ctx context.Context, id uint) (*models.PaymentMethod, error)
+	GetPaymentMethodsByUserID(ctx context.Context, userID uint) ([]models.PaymentMethod, error)
+	UpdatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error
+	DeletePaymentMethod(ctx context.Context, id uint) error
 }
 
 // PaymentMethodRepository handles DB operations for payment methods
@@ -25,14 +27,14 @@ func NewPaymentMethodRepository(db *gorm.DB) *GormPaymentMethodRepository {
 }
 
 // CreatePaymentMethod inserts a new payment method into the database
-func (r *GormPaymentMethodRepository) CreatePaymentMethod(paymentMethod *models.PaymentMethod) error {
-	return r.db.Create(paymentMethod).Error
+func (r *GormPaymentMethodRepository) CreatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error {
+	return r.db.WithContext(ctx).Create(paymentMethod).Error
 }
 
 // GetPaymentMethodByID retrieves a payment method by its ID
-func (r *GormPaymentMethodRepository) GetPaymentMethodByID(id uint) (*models.PaymentMethod, error) {
+func (r *GormPaymentMethodRepository) GetPaymentMethodByID(ctx context.Context, id uint) (*models.PaymentMethod, error) {
 	var paymentMethod models.PaymentMethod
-	err := r.db.First(&paymentMethod, id).Error
+	err := r.db.WithContext(ctx).First(&paymentMethod, id).Error
 	if err != nil {
 		return nil, err
 	}
@@ -40,18 +42,18 @@ func (r *GormPaymentMethodRepository) GetPaymentMethodByID(id uint) (*models.Pay
 }
 
 // GetPaymentMethodsByUserID fetches all payment methods for a specific user
-func (r *GormPaymentMethodRepository) GetPaymentMethodsByUserID(userID uint) ([]models.PaymentMethod, error) {
+func (r *GormPaymentMethodRepository) GetPaymentMethodsByUserID(ctx context.Context, userID uint) ([]models.PaymentMethod, error) {
 	var paymentMethods []models.PaymentMethod
-	err := r.db.Where("user_id = ?", userID).Find(&paymentMethods).Error
+	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Find(&paymentMethods).Error
 	return paymentMethods, err
 }
 
 // UpdatePaymentMethod updates an existing payment method
-func (r *GormPaymentMethodRepository) UpdatePaymentMethod(paymentMethod *models.PaymentMethod) error {
-	return r.db.Save(paymentMethod).Error
+func (r *GormPaymentMethodRepository) UpdatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error {
+	return r.db.WithContext(ctx).Save(paymentMethod).Error
 }
 
 // DeletePaymentMethod removes a payment method from the database
-func (r *GormPaymentMethodRepository) DeletePaymentMethod(id uint) error {
-	return r.db.Delete(&models.PaymentMethod{}, id).Error
+func (r *GormPaymentMethodRepository) DeletePaymentMethod(ctx context.Context, id uint) error {
+	return r.db.WithContext(ctx).Delete(&models.PaymentMethod{}, id).Error
 }

--- a/internal/repositories/gorm/gorm_payment_method_repository_test.go
+++ b/internal/repositories/gorm/gorm_payment_method_repository_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"testing"
 
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
@@ -21,6 +22,7 @@ func setupPaymentTestDB(t *testing.T) *gorm.DB {
 func TestCreatePaymentMethod(t *testing.T) {
 	db := setupPaymentTestDB(t)
 	repo := NewPaymentMethodRepository(db)
+	ctx := context.Background()
 
 	// Ensure related entity (User) exists
 	user := &models.User{Name: "Test User", Email: "test@example.com", Password: "hashedpassword"}
@@ -28,7 +30,7 @@ func TestCreatePaymentMethod(t *testing.T) {
 
 	t.Run("Create valid payment method", func(t *testing.T) {
 		paymentMethod := &models.PaymentMethod{Name: "Credit Card", UserID: user.ID}
-		err := repo.CreatePaymentMethod(paymentMethod)
+		err := repo.CreatePaymentMethod(ctx, paymentMethod)
 		assert.NoError(t, err)
 
 		var retrievedPaymentMethod models.PaymentMethod
@@ -41,10 +43,10 @@ func TestCreatePaymentMethod(t *testing.T) {
 		paymentMethod1 := &models.PaymentMethod{Name: "PayPal", UserID: user.ID}
 		paymentMethod2 := &models.PaymentMethod{Name: "PayPal", UserID: user.ID} // Duplicate
 
-		err := repo.CreatePaymentMethod(paymentMethod1)
+		err := repo.CreatePaymentMethod(ctx, paymentMethod1)
 		assert.NoError(t, err)
 
-		err = repo.CreatePaymentMethod(paymentMethod2) // Should fail due to unique constraint
+		err = repo.CreatePaymentMethod(ctx, paymentMethod2) // Should fail due to unique constraint
 		assert.Error(t, err)
 	})
 }
@@ -53,6 +55,7 @@ func TestCreatePaymentMethod(t *testing.T) {
 func TestGetPaymentMethodByID(t *testing.T) {
 	db := setupPaymentTestDB(t)
 	repo := NewPaymentMethodRepository(db)
+	ctx := context.Background()
 
 	// Ensure related entity (User) exists
 	user := &models.User{Name: "Test User", Email: "test@example.com", Password: "hashedpassword"}
@@ -60,17 +63,17 @@ func TestGetPaymentMethodByID(t *testing.T) {
 
 	t.Run("Retrieve existing payment method", func(t *testing.T) {
 		paymentMethod := &models.PaymentMethod{Name: "Debit Card", UserID: user.ID}
-		err := repo.CreatePaymentMethod(paymentMethod)
+		err := repo.CreatePaymentMethod(ctx, paymentMethod)
 		assert.NoError(t, err)
 
-		foundPaymentMethod, err := repo.GetPaymentMethodByID(paymentMethod.ID)
+		foundPaymentMethod, err := repo.GetPaymentMethodByID(ctx, paymentMethod.ID)
 		assert.NoError(t, err)
 		assert.NotNil(t, foundPaymentMethod)
 		assert.Equal(t, paymentMethod.Name, foundPaymentMethod.Name)
 	})
 
 	t.Run("Retrieve non-existent payment method", func(t *testing.T) {
-		paymentMethod, err := repo.GetPaymentMethodByID(9999) // Non-existent ID
+		paymentMethod, err := repo.GetPaymentMethodByID(ctx, 9999) // Non-existent ID
 		assert.Error(t, err)
 		assert.Nil(t, paymentMethod)
 		assert.Equal(t, gorm.ErrRecordNotFound, err)
@@ -81,6 +84,7 @@ func TestGetPaymentMethodByID(t *testing.T) {
 func TestGetPaymentMethodsByUserID(t *testing.T) {
 	db := setupPaymentTestDB(t)
 	repo := NewPaymentMethodRepository(db)
+	ctx := context.Background()
 
 	// Ensure related entity (User) exists
 	user := &models.User{Name: "Test User", Email: "test@example.com", Password: "hashedpassword"}
@@ -89,18 +93,18 @@ func TestGetPaymentMethodsByUserID(t *testing.T) {
 	t.Run("User has multiple payment methods", func(t *testing.T) {
 		paymentMethod1 := &models.PaymentMethod{Name: "Apple Pay", UserID: user.ID}
 		paymentMethod2 := &models.PaymentMethod{Name: "Google Pay", UserID: user.ID}
-		err1 := repo.CreatePaymentMethod(paymentMethod1)
+		err1 := repo.CreatePaymentMethod(ctx, paymentMethod1)
 		assert.NoError(t, err1)
-		err2 := repo.CreatePaymentMethod(paymentMethod2)
+		err2 := repo.CreatePaymentMethod(ctx, paymentMethod2)
 		assert.NoError(t, err2)
 
-		paymentMethods, err := repo.GetPaymentMethodsByUserID(user.ID)
+		paymentMethods, err := repo.GetPaymentMethodsByUserID(ctx, user.ID)
 		assert.NoError(t, err)
 		assert.Len(t, paymentMethods, 2)
 	})
 
 	t.Run("User has no payment methods", func(t *testing.T) {
-		paymentMethods, err := repo.GetPaymentMethodsByUserID(9999) // Non-existent user
+		paymentMethods, err := repo.GetPaymentMethodsByUserID(ctx, 9999) // Non-existent user
 		assert.NoError(t, err)
 		assert.Len(t, paymentMethods, 0)
 	})
@@ -110,6 +114,7 @@ func TestGetPaymentMethodsByUserID(t *testing.T) {
 func TestUpdatePaymentMethod(t *testing.T) {
 	db := setupPaymentTestDB(t)
 	repo := NewPaymentMethodRepository(db)
+	ctx := context.Background()
 
 	// Ensure related entity (User) exists
 	user := &models.User{Name: "Test User", Email: "test@example.com", Password: "hashedpassword"}
@@ -117,12 +122,12 @@ func TestUpdatePaymentMethod(t *testing.T) {
 
 	t.Run("Update existing payment method", func(t *testing.T) {
 		paymentMethod := &models.PaymentMethod{Name: "Bank Transfer", UserID: user.ID}
-		err1 := repo.CreatePaymentMethod(paymentMethod)
+		err1 := repo.CreatePaymentMethod(ctx, paymentMethod)
 		assert.NoError(t, err1)
 
 		// Update the payment method
 		paymentMethod.Name = "Wire Transfer"
-		err := repo.UpdatePaymentMethod(paymentMethod)
+		err := repo.UpdatePaymentMethod(ctx, paymentMethod)
 		assert.NoError(t, err)
 
 		// Fetch updated payment method
@@ -137,6 +142,7 @@ func TestUpdatePaymentMethod(t *testing.T) {
 func TestDeletePaymentMethod(t *testing.T) {
 	db := setupPaymentTestDB(t)
 	repo := NewPaymentMethodRepository(db)
+	ctx := context.Background()
 
 	// Ensure related entity (User) exists
 	user := &models.User{Name: "Test User", Email: "test@example.com", Password: "hashedpassword"}
@@ -144,10 +150,10 @@ func TestDeletePaymentMethod(t *testing.T) {
 
 	t.Run("Delete existing payment method", func(t *testing.T) {
 		paymentMethod := &models.PaymentMethod{Name: "Venmo", UserID: user.ID}
-		err1 := repo.CreatePaymentMethod(paymentMethod)
+		err1 := repo.CreatePaymentMethod(ctx, paymentMethod)
 		assert.NoError(t, err1)
 
-		err := repo.DeletePaymentMethod(paymentMethod.ID)
+		err := repo.DeletePaymentMethod(ctx, paymentMethod.ID)
 		assert.NoError(t, err)
 
 		var deletedPaymentMethod models.PaymentMethod
@@ -157,7 +163,7 @@ func TestDeletePaymentMethod(t *testing.T) {
 	})
 
 	t.Run("Delete non-existent payment method", func(t *testing.T) {
-		err := repo.DeletePaymentMethod(9999) // Non-existent ID
-		assert.NoError(t, err)                // `gorm.Delete` does not return an error if the record doesn't exist
+		err := repo.DeletePaymentMethod(ctx, 9999) // Non-existent ID
+		assert.NoError(t, err)                     // `gorm.Delete` does not return an error if the record doesn't exist
 	})
 }

--- a/internal/repositories/gorm/gorm_transaction_repository.go
+++ b/internal/repositories/gorm/gorm_transaction_repository.go
@@ -1,17 +1,19 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"gorm.io/gorm"
 )
 
 // TransactionRepository defines the required repository methods
 type TransactionRepository interface {
-	CreateTransaction(transaction *models.Transaction) error
-	GetTransactionByID(id uint) (*models.Transaction, error)
-	GetTransactionsByUserID(userID uint) ([]models.Transaction, error)
-	UpdateTransaction(transaction *models.Transaction) error
-	DeleteTransaction(id uint) error
+	CreateTransaction(ctx context.Context, transaction *models.Transaction) error
+	GetTransactionByID(ctx context.Context, id uint) (*models.Transaction, error)
+	GetTransactionsByUserID(ctx context.Context, userID uint) ([]models.Transaction, error)
+	UpdateTransaction(ctx context.Context, transaction *models.Transaction) error
+	DeleteTransaction(ctx context.Context, id uint) error
 }
 
 // TransactionRepository handles DB operations for transactions
@@ -25,14 +27,14 @@ func NewTransactionRepository(db *gorm.DB) *GormTransactionRepository {
 }
 
 // CreateTransaction inserts a new transaction into the database
-func (r *GormTransactionRepository) CreateTransaction(transaction *models.Transaction) error {
-	return r.db.Create(transaction).Error
+func (r *GormTransactionRepository) CreateTransaction(ctx context.Context, transaction *models.Transaction) error {
+	return r.db.WithContext(ctx).Create(transaction).Error
 }
 
 // GetTransactionByID retrieves a transaction by its ID
-func (r *GormTransactionRepository) GetTransactionByID(id uint) (*models.Transaction, error) {
+func (r *GormTransactionRepository) GetTransactionByID(ctx context.Context, id uint) (*models.Transaction, error) {
 	var transaction models.Transaction
-	err := r.db.First(&transaction, id).Error
+	err := r.db.WithContext(ctx).First(&transaction, id).Error
 	if err != nil {
 		return nil, err
 	}
@@ -40,18 +42,18 @@ func (r *GormTransactionRepository) GetTransactionByID(id uint) (*models.Transac
 }
 
 // GetTransactionsByUserID fetches all transactions for a specific user
-func (r *GormTransactionRepository) GetTransactionsByUserID(userID uint) ([]models.Transaction, error) {
+func (r *GormTransactionRepository) GetTransactionsByUserID(ctx context.Context, userID uint) ([]models.Transaction, error) {
 	var transactions []models.Transaction
-	err := r.db.Where("user_id = ?", userID).Find(&transactions).Error
+	err := r.db.WithContext(ctx).Where("user_id = ?", userID).Find(&transactions).Error
 	return transactions, err
 }
 
 // UpdateTransaction updates an existing transaction
-func (r *GormTransactionRepository) UpdateTransaction(transaction *models.Transaction) error {
-	return r.db.Save(transaction).Error
+func (r *GormTransactionRepository) UpdateTransaction(ctx context.Context, transaction *models.Transaction) error {
+	return r.db.WithContext(ctx).Save(transaction).Error
 }
 
 // DeleteTransaction removes a transaction from the database
-func (r *GormTransactionRepository) DeleteTransaction(id uint) error {
-	return r.db.Delete(&models.Transaction{}, id).Error
+func (r *GormTransactionRepository) DeleteTransaction(ctx context.Context, id uint) error {
+	return r.db.WithContext(ctx).Delete(&models.Transaction{}, id).Error
 }

--- a/internal/repositories/gorm/gorm_transaction_repository_test.go
+++ b/internal/repositories/gorm/gorm_transaction_repository_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ func setupTransactionTestDB(t *testing.T) *gorm.DB {
 func TestTransactionRepository(t *testing.T) {
 	db := setupTransactionTestDB(t)
 	repo := NewTransactionRepository(db)
+	ctx := context.Background()
 
 	// Create a test user for transactions
 	user := &models.User{Name: "Test User", Email: "test@example.com", Password: "hashedpassword"}
@@ -37,7 +39,7 @@ func TestTransactionRepository(t *testing.T) {
 			Note:       "Test transaction",
 		}
 
-		err := repo.CreateTransaction(transaction)
+		err := repo.CreateTransaction(ctx, transaction)
 		assert.NoError(t, err)
 
 		// Verify transaction was inserted
@@ -56,17 +58,17 @@ func TestTransactionRepository(t *testing.T) {
 			Date:       time.Now(),
 			Note:       "Salary payment",
 		}
-		err := repo.CreateTransaction(transaction)
+		err := repo.CreateTransaction(ctx, transaction)
 		assert.NoError(t, err)
 
-		foundTransaction, err := repo.GetTransactionByID(transaction.ID)
+		foundTransaction, err := repo.GetTransactionByID(ctx, transaction.ID)
 		assert.NoError(t, err)
 		assert.NotNil(t, foundTransaction)
 		assert.Equal(t, transaction.Amount, foundTransaction.Amount)
 	})
 
 	t.Run("GetTransactionByID_NotFound", func(t *testing.T) {
-		transaction, err := repo.GetTransactionByID(9999) // Non-existent ID
+		transaction, err := repo.GetTransactionByID(ctx, 9999) // Non-existent ID
 		assert.Error(t, err)
 		assert.Nil(t, transaction)
 		assert.Equal(t, gorm.ErrRecordNotFound, err)
@@ -76,12 +78,12 @@ func TestTransactionRepository(t *testing.T) {
 		// Reset transactions before running test
 		db.Session(&gorm.Session{AllowGlobalUpdate: true}).Delete(&models.Transaction{})
 
-		err1 := repo.CreateTransaction(&models.Transaction{UserID: user.ID, Type: "expense", Amount: 50, CategoryID: 1, Date: time.Now()})
+		err1 := repo.CreateTransaction(ctx, &models.Transaction{UserID: user.ID, Type: "expense", Amount: 50, CategoryID: 1, Date: time.Now()})
 		assert.NoError(t, err1)
-		err2 := repo.CreateTransaction(&models.Transaction{UserID: user.ID, Type: "income", Amount: 150, CategoryID: 2, Date: time.Now()})
+		err2 := repo.CreateTransaction(ctx, &models.Transaction{UserID: user.ID, Type: "income", Amount: 150, CategoryID: 2, Date: time.Now()})
 		assert.NoError(t, err2)
 
-		transactions, err := repo.GetTransactionsByUserID(user.ID)
+		transactions, err := repo.GetTransactionsByUserID(ctx, user.ID)
 		assert.NoError(t, err)
 		assert.Len(t, transactions, 2) // Ensure we only have 2 transactions
 	})
@@ -95,16 +97,16 @@ func TestTransactionRepository(t *testing.T) {
 			Date:       time.Now(),
 			Note:       "Old transaction",
 		}
-		err1 := repo.CreateTransaction(transaction)
+		err1 := repo.CreateTransaction(ctx, transaction)
 		assert.NoError(t, err1)
 
 		transaction.Amount = 600.00 // Update amount
 		transaction.Note = "Updated transaction"
-		err := repo.UpdateTransaction(transaction)
+		err := repo.UpdateTransaction(ctx, transaction)
 		assert.NoError(t, err)
 
 		// Verify update
-		updatedTransaction, err := repo.GetTransactionByID(transaction.ID)
+		updatedTransaction, err := repo.GetTransactionByID(ctx, transaction.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, 600.00, updatedTransaction.Amount)
 		assert.Equal(t, "Updated transaction", updatedTransaction.Note)
@@ -119,10 +121,10 @@ func TestTransactionRepository(t *testing.T) {
 			Date:       time.Now(),
 			Note:       "To be deleted",
 		}
-		err1 := repo.CreateTransaction(transaction)
+		err1 := repo.CreateTransaction(ctx, transaction)
 		assert.NoError(t, err1)
 
-		err := repo.DeleteTransaction(transaction.ID)
+		err := repo.DeleteTransaction(ctx, transaction.ID)
 		assert.NoError(t, err)
 
 		// Verify deletion

--- a/internal/repositories/gorm/gorm_user_repository.go
+++ b/internal/repositories/gorm/gorm_user_repository.go
@@ -1,14 +1,16 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"gorm.io/gorm"
 )
 
 // UserRepository defines the required repository methods
 type UserRepository interface {
-	CreateUser(user *models.User) error
-	GetUserByEmail(email string) (*models.User, error)
+	CreateUser(ctx context.Context, user *models.User) error
+	GetUserByEmail(ctx context.Context, email string) (*models.User, error)
 }
 
 // GormUserRepository handles DB operations for users
@@ -22,14 +24,14 @@ func NewUserRepository(db *gorm.DB) *GormUserRepository {
 }
 
 // CreateUser inserts a new user into the database
-func (r *GormUserRepository) CreateUser(user *models.User) error {
-	return r.db.Create(user).Error
+func (r *GormUserRepository) CreateUser(ctx context.Context, user *models.User) error {
+	return r.db.WithContext(ctx).Create(user).Error
 }
 
 // GetUserByEmail retrieves a user by email
-func (r *GormUserRepository) GetUserByEmail(email string) (*models.User, error) {
+func (r *GormUserRepository) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
 	var user models.User
-	err := r.db.Where("email = ?", email).First(&user).Error
+	err := r.db.WithContext(ctx).Where("email = ?", email).First(&user).Error
 	if err != nil {
 		return nil, err
 	}
@@ -37,6 +39,6 @@ func (r *GormUserRepository) GetUserByEmail(email string) (*models.User, error) 
 }
 
 // DeleteUser removes a user from the database
-func (r *GormUserRepository) DeleteUser(id uint) error {
-	return r.db.Delete(&models.User{}, id).Error
+func (r *GormUserRepository) DeleteUser(ctx context.Context, id uint) error {
+	return r.db.WithContext(ctx).Delete(&models.User{}, id).Error
 }

--- a/internal/repositories/gorm/gorm_user_repository_test.go
+++ b/internal/repositories/gorm/gorm_user_repository_test.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"testing"
 
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/database"
@@ -20,11 +21,12 @@ func setupTestDB(t *testing.T) *gorm.DB {
 func TestUserRepository(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewUserRepository(db)
+	ctx := context.Background()
 
 	t.Run("should create a new user", func(t *testing.T) {
 		user := &models.User{Name: "John Doe", Email: "john@example.com", Password: "hashedpassword"}
 
-		err := repo.CreateUser(user)
+		err := repo.CreateUser(ctx, user)
 		assert.NoError(t, err)
 
 		var retrievedUser models.User
@@ -35,10 +37,10 @@ func TestUserRepository(t *testing.T) {
 
 	t.Run("should retrieve a user by email", func(t *testing.T) {
 		user := &models.User{Name: "Jane Doe", Email: "jane@example.com", Password: "hashedpassword"}
-		err := repo.CreateUser(user)
+		err := repo.CreateUser(ctx, user)
 		assert.NoError(t, err)
 
-		foundUser, err := repo.GetUserByEmail("jane@example.com")
+		foundUser, err := repo.GetUserByEmail(ctx, "jane@example.com")
 		assert.NoError(t, err)
 		assert.NotNil(t, foundUser)
 		assert.Equal(t, "Jane Doe", foundUser.Name)
@@ -46,10 +48,10 @@ func TestUserRepository(t *testing.T) {
 
 	t.Run("should delete a user", func(t *testing.T) {
 		user := &models.User{Name: "Mark Smith", Email: "mark@example.com", Password: "hashedpassword"}
-		err1 := repo.CreateUser(user)
+		err1 := repo.CreateUser(ctx, user)
 		assert.NoError(t, err1)
 
-		err := repo.DeleteUser(user.ID)
+		err := repo.DeleteUser(ctx, user.ID)
 		assert.NoError(t, err)
 
 		var retrievedUser models.User
@@ -60,7 +62,7 @@ func TestUserRepository(t *testing.T) {
 		repo := NewUserRepository(db)
 
 		// Attempt to fetch a non-existent user
-		user, err := repo.GetUserByEmail("nonexistent@example.com")
+		user, err := repo.GetUserByEmail(ctx, "nonexistent@example.com")
 
 		// This should trigger the missing error branch
 		assert.Error(t, err)

--- a/internal/repositories/payment_method_repository.go
+++ b/internal/repositories/payment_method_repository.go
@@ -1,14 +1,16 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // PaymentMethodRepository defines the required repository methods
 type PaymentMethodRepository interface {
-	CreatePaymentMethod(paymentMethod *models.PaymentMethod) error
-	GetPaymentMethodByID(id uint) (*models.PaymentMethod, error)
-	GetPaymentMethodsByUserID(userID uint) ([]models.PaymentMethod, error)
-	UpdatePaymentMethod(paymentMethod *models.PaymentMethod) error
-	DeletePaymentMethod(id uint) error
+	CreatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error
+	GetPaymentMethodByID(ctx context.Context, id uint) (*models.PaymentMethod, error)
+	GetPaymentMethodsByUserID(ctx context.Context, userID uint) ([]models.PaymentMethod, error)
+	UpdatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error
+	DeletePaymentMethod(ctx context.Context, id uint) error
 }

--- a/internal/repositories/transaction_repository.go
+++ b/internal/repositories/transaction_repository.go
@@ -1,14 +1,16 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // TransactionRepository defines the required repository methods
 type TransactionRepository interface {
-	CreateTransaction(transaction *models.Transaction) error
-	GetTransactionByID(id uint) (*models.Transaction, error)
-	GetTransactionsByUserID(userID uint) ([]models.Transaction, error)
-	UpdateTransaction(transaction *models.Transaction) error
-	DeleteTransaction(id uint) error
+	CreateTransaction(ctx context.Context, transaction *models.Transaction) error
+	GetTransactionByID(ctx context.Context, id uint) (*models.Transaction, error)
+	GetTransactionsByUserID(ctx context.Context, userID uint) ([]models.Transaction, error)
+	UpdateTransaction(ctx context.Context, transaction *models.Transaction) error
+	DeleteTransaction(ctx context.Context, id uint) error
 }

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -1,11 +1,13 @@
 package repositories
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // UserRepository defines the required repository methods
 type UserRepository interface {
-	CreateUser(user *models.User) error
-	GetUserByEmail(email string) (*models.User, error)
+	CreateUser(ctx context.Context, user *models.User) error
+	GetUserByEmail(ctx context.Context, email string) (*models.User, error)
 }

--- a/internal/services/budget_service.go
+++ b/internal/services/budget_service.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 type BudgetService interface {
-	CreateBudget(budget *models.Budget) error
-	UpdateBudget(budget *models.Budget) error
-	GetBudgetsByUser(userID uint) ([]models.Budget, error)
-	DeleteBudgetForUser(userID, budgetID uint) error
+	CreateBudget(ctx context.Context, budget *models.Budget) error
+	UpdateBudget(ctx context.Context, budget *models.Budget) error
+	GetBudgetsByUser(ctx context.Context, userID uint) ([]models.Budget, error)
+	DeleteBudgetForUser(ctx context.Context, userID, budgetID uint) error
 }

--- a/internal/services/category_service.go
+++ b/internal/services/category_service.go
@@ -1,13 +1,15 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // CategoryService defines the interface for category operations
 type CategoryService interface {
-	CreateCategory(category *models.Category) error
-	GetCategories() ([]models.Category, error)
-	UpdateCategory(category *models.Category) error
-	DeleteCategory(categoryID uint) error
+	CreateCategory(ctx context.Context, category *models.Category) error
+	GetCategories(ctx context.Context) ([]models.Category, error)
+	UpdateCategory(ctx context.Context, category *models.Category) error
+	DeleteCategory(ctx context.Context, categoryID uint) error
 }

--- a/internal/services/default/default_budget_service.go
+++ b/internal/services/default/default_budget_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/apperrors"
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/repositories"
@@ -15,7 +17,7 @@ func NewBudgetService(budgetRepo repositories.BudgetRepository) *DefaultBudgetSe
 }
 
 // CreateBudget validates and adds a budget
-func (s *DefaultBudgetService) CreateBudget(budget *models.Budget) error {
+func (s *DefaultBudgetService) CreateBudget(ctx context.Context, budget *models.Budget) error {
 	if budget.Limit <= 0 {
 		return apperrors.Validation("invalid_budget_limit", "budget limit must be greater than zero")
 	}
@@ -24,7 +26,7 @@ func (s *DefaultBudgetService) CreateBudget(budget *models.Budget) error {
 		return apperrors.Validation("invalid_budget_date_range", "start date cannot be after end date")
 	}
 
-	if err := s.budgetRepo.CreateBudget(budget); err != nil {
+	if err := s.budgetRepo.CreateBudget(ctx, budget); err != nil {
 		return apperrors.Internal("budget_create_failed", "failed to create budget", err)
 	}
 
@@ -32,7 +34,7 @@ func (s *DefaultBudgetService) CreateBudget(budget *models.Budget) error {
 }
 
 // UpdateBudget modifies an existing budget
-func (s *DefaultBudgetService) UpdateBudget(budget *models.Budget) error {
+func (s *DefaultBudgetService) UpdateBudget(ctx context.Context, budget *models.Budget) error {
 	if budget.Limit <= 0 {
 		return apperrors.Validation("invalid_budget_limit", "budget limit must be positive")
 	}
@@ -41,7 +43,7 @@ func (s *DefaultBudgetService) UpdateBudget(budget *models.Budget) error {
 		return apperrors.Validation("invalid_budget_date_range", "start date cannot be after end date")
 	}
 
-	if err := s.budgetRepo.UpdateBudget(budget); err != nil {
+	if err := s.budgetRepo.UpdateBudget(ctx, budget); err != nil {
 		return apperrors.Internal("budget_update_failed", "failed to update budget", err)
 	}
 
@@ -49,8 +51,8 @@ func (s *DefaultBudgetService) UpdateBudget(budget *models.Budget) error {
 }
 
 // GetBudgetsByUser retrieves budgets for a user
-func (s *DefaultBudgetService) GetBudgetsByUser(userID uint) ([]models.Budget, error) {
-	budgets, err := s.budgetRepo.GetBudgetsByUserID(userID)
+func (s *DefaultBudgetService) GetBudgetsByUser(ctx context.Context, userID uint) ([]models.Budget, error) {
+	budgets, err := s.budgetRepo.GetBudgetsByUserID(ctx, userID)
 	if err != nil {
 		return nil, apperrors.Internal("budgets_fetch_failed", "failed to retrieve budgets", err)
 	}
@@ -59,8 +61,8 @@ func (s *DefaultBudgetService) GetBudgetsByUser(userID uint) ([]models.Budget, e
 }
 
 // DeleteBudgetForUser removes a budget that belongs to the authenticated user.
-func (s *DefaultBudgetService) DeleteBudgetForUser(userID, budgetID uint) error {
-	budget, err := s.budgetRepo.GetBudgetByID(budgetID)
+func (s *DefaultBudgetService) DeleteBudgetForUser(ctx context.Context, userID, budgetID uint) error {
+	budget, err := s.budgetRepo.GetBudgetByID(ctx, budgetID)
 	if err != nil {
 		return apperrors.NotFound("budget_not_found", "budget not found")
 	}
@@ -69,7 +71,7 @@ func (s *DefaultBudgetService) DeleteBudgetForUser(userID, budgetID uint) error 
 		return apperrors.NotFound("budget_not_found", "budget not found")
 	}
 
-	if err := s.budgetRepo.DeleteBudget(budgetID); err != nil {
+	if err := s.budgetRepo.DeleteBudget(ctx, budgetID); err != nil {
 		return apperrors.Internal("budget_delete_failed", "failed to delete budget", err)
 	}
 

--- a/internal/services/default/default_budget_service_test.go
+++ b/internal/services/default/default_budget_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -16,37 +17,38 @@ type MockBudgetRepository struct {
 	mock.Mock
 }
 
-func (m *MockBudgetRepository) CreateBudget(budget *models.Budget) error {
-	args := m.Called(budget)
+func (m *MockBudgetRepository) CreateBudget(ctx context.Context, budget *models.Budget) error {
+	args := m.Called(ctx, budget)
 	return args.Error(0)
 }
 
-func (m *MockBudgetRepository) GetBudgetByID(id uint) (*models.Budget, error) {
-	args := m.Called(id)
+func (m *MockBudgetRepository) GetBudgetByID(ctx context.Context, id uint) (*models.Budget, error) {
+	args := m.Called(ctx, id)
 	if args.Get(0) != nil {
 		return args.Get(0).(*models.Budget), args.Error(1)
 	}
 	return nil, args.Error(1)
 }
 
-func (m *MockBudgetRepository) GetBudgetsByUserID(userID uint) ([]models.Budget, error) {
-	args := m.Called(userID)
+func (m *MockBudgetRepository) GetBudgetsByUserID(ctx context.Context, userID uint) ([]models.Budget, error) {
+	args := m.Called(ctx, userID)
 	return args.Get(0).([]models.Budget), args.Error(1)
 }
 
-func (m *MockBudgetRepository) UpdateBudget(budget *models.Budget) error {
-	args := m.Called(budget)
+func (m *MockBudgetRepository) UpdateBudget(ctx context.Context, budget *models.Budget) error {
+	args := m.Called(ctx, budget)
 	return args.Error(0)
 }
 
-func (m *MockBudgetRepository) DeleteBudget(id uint) error {
-	args := m.Called(id)
+func (m *MockBudgetRepository) DeleteBudget(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
 func TestCreateBudget(t *testing.T) {
 	mockRepo := new(MockBudgetRepository)
 	service := NewBudgetService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Create valid budget", func(t *testing.T) {
 		budget := &models.Budget{
@@ -57,9 +59,9 @@ func TestCreateBudget(t *testing.T) {
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
 
-		mockRepo.On("CreateBudget", budget).Return(nil)
+		mockRepo.On("CreateBudget", ctx, budget).Return(nil)
 
-		err := service.CreateBudget(budget)
+		err := service.CreateBudget(ctx, budget)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
@@ -73,7 +75,7 @@ func TestCreateBudget(t *testing.T) {
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
 
-		err := service.CreateBudget(budget)
+		err := service.CreateBudget(ctx, budget)
 		assert.Error(t, err)
 		assert.Equal(t, "budget limit must be greater than zero", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindValidation))
@@ -89,7 +91,7 @@ func TestCreateBudget(t *testing.T) {
 			EndDate:    time.Now(),
 		}
 
-		err := service.CreateBudget(budget)
+		err := service.CreateBudget(ctx, budget)
 		assert.Error(t, err)
 		assert.Equal(t, "start date cannot be after end date", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindValidation))
@@ -100,6 +102,7 @@ func TestCreateBudget(t *testing.T) {
 func TestUpdateBudget(t *testing.T) {
 	mockRepo := new(MockBudgetRepository)
 	service := NewBudgetService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Update existing budget", func(t *testing.T) {
 		budget := &models.Budget{
@@ -111,9 +114,9 @@ func TestUpdateBudget(t *testing.T) {
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
 
-		mockRepo.On("UpdateBudget", budget).Return(nil)
+		mockRepo.On("UpdateBudget", ctx, budget).Return(nil)
 
-		err := service.UpdateBudget(budget)
+		err := service.UpdateBudget(ctx, budget)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
@@ -128,7 +131,7 @@ func TestUpdateBudget(t *testing.T) {
 			EndDate:    time.Now().AddDate(0, 1, 0),
 		}
 
-		err := service.UpdateBudget(budget)
+		err := service.UpdateBudget(ctx, budget)
 		assert.Error(t, err)
 		assert.Equal(t, "budget limit must be positive", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindValidation))
@@ -145,7 +148,7 @@ func TestUpdateBudget(t *testing.T) {
 			EndDate:    time.Now(),
 		}
 
-		err := service.UpdateBudget(budget)
+		err := service.UpdateBudget(ctx, budget)
 		assert.Error(t, err)
 		assert.Equal(t, "start date cannot be after end date", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindValidation))
@@ -156,6 +159,7 @@ func TestUpdateBudget(t *testing.T) {
 func TestGetBudgetsByUser(t *testing.T) {
 	mockRepo := new(MockBudgetRepository)
 	service := NewBudgetService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Retrieve budgets for user", func(t *testing.T) {
 		budgets := []models.Budget{
@@ -163,18 +167,18 @@ func TestGetBudgetsByUser(t *testing.T) {
 			{ID: 2, UserID: 1, CategoryID: 3, Limit: 500},
 		}
 
-		mockRepo.On("GetBudgetsByUserID", uint(1)).Return(budgets, nil)
+		mockRepo.On("GetBudgetsByUserID", ctx, uint(1)).Return(budgets, nil)
 
-		result, err := service.GetBudgetsByUser(1)
+		result, err := service.GetBudgetsByUser(ctx, 1)
 		assert.NoError(t, err)
 		assert.Len(t, result, 2)
 		mockRepo.AssertExpectations(t)
 	})
 
 	t.Run("Retrieve budgets for user with no budgets", func(t *testing.T) {
-		mockRepo.On("GetBudgetsByUserID", uint(999)).Return([]models.Budget{}, nil)
+		mockRepo.On("GetBudgetsByUserID", ctx, uint(999)).Return([]models.Budget{}, nil)
 
-		result, err := service.GetBudgetsByUser(999)
+		result, err := service.GetBudgetsByUser(ctx, 999)
 		assert.NoError(t, err)
 		assert.Len(t, result, 0)
 		mockRepo.AssertExpectations(t)
@@ -184,20 +188,21 @@ func TestGetBudgetsByUser(t *testing.T) {
 func TestDeleteBudget(t *testing.T) {
 	mockRepo := new(MockBudgetRepository)
 	service := NewBudgetService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Delete existing budget", func(t *testing.T) {
-		mockRepo.On("GetBudgetByID", uint(1)).Return(&models.Budget{ID: 1, UserID: 1}, nil)
-		mockRepo.On("DeleteBudget", uint(1)).Return(nil)
+		mockRepo.On("GetBudgetByID", ctx, uint(1)).Return(&models.Budget{ID: 1, UserID: 1}, nil)
+		mockRepo.On("DeleteBudget", ctx, uint(1)).Return(nil)
 
-		err := service.DeleteBudgetForUser(1, 1)
+		err := service.DeleteBudgetForUser(ctx, 1, 1)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
 
 	t.Run("Fail to delete non-existent budget", func(t *testing.T) {
-		mockRepo.On("GetBudgetByID", uint(9999)).Return(nil, errors.New("budget not found"))
+		mockRepo.On("GetBudgetByID", ctx, uint(9999)).Return(nil, errors.New("budget not found"))
 
-		err := service.DeleteBudgetForUser(1, 9999)
+		err := service.DeleteBudgetForUser(ctx, 1, 9999)
 		assert.Error(t, err)
 		assert.Equal(t, "budget not found", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindNotFound))
@@ -205,9 +210,9 @@ func TestDeleteBudget(t *testing.T) {
 	})
 
 	t.Run("Fail to delete another user's budget", func(t *testing.T) {
-		mockRepo.On("GetBudgetByID", uint(2)).Return(&models.Budget{ID: 2, UserID: 99}, nil)
+		mockRepo.On("GetBudgetByID", ctx, uint(2)).Return(&models.Budget{ID: 2, UserID: 99}, nil)
 
-		err := service.DeleteBudgetForUser(1, 2)
+		err := service.DeleteBudgetForUser(ctx, 1, 2)
 		assert.Error(t, err)
 		assert.Equal(t, "budget not found", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindNotFound))

--- a/internal/services/default/default_category_service.go
+++ b/internal/services/default/default_category_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/repositories"
 )
@@ -15,18 +17,18 @@ func NewCategoryService(categoryRepo repositories.CategoryRepository) DefaultCat
 	return DefaultCategoryService{categoryRepo: categoryRepo}
 }
 
-func (s *DefaultCategoryService) CreateCategory(category *models.Category) error {
-	return s.categoryRepo.CreateCategory(category)
+func (s *DefaultCategoryService) CreateCategory(ctx context.Context, category *models.Category) error {
+	return s.categoryRepo.CreateCategory(ctx, category)
 }
 
-func (s *DefaultCategoryService) GetCategories() ([]models.Category, error) {
-	return s.categoryRepo.GetAllCategories()
+func (s *DefaultCategoryService) GetCategories(ctx context.Context) ([]models.Category, error) {
+	return s.categoryRepo.GetAllCategories(ctx)
 }
 
-func (s *DefaultCategoryService) UpdateCategory(category *models.Category) error {
-	return s.categoryRepo.UpdateCategory(category)
+func (s *DefaultCategoryService) UpdateCategory(ctx context.Context, category *models.Category) error {
+	return s.categoryRepo.UpdateCategory(ctx, category)
 }
 
-func (s *DefaultCategoryService) DeleteCategory(categoryID uint) error {
-	return s.categoryRepo.DeleteCategory(categoryID)
+func (s *DefaultCategoryService) DeleteCategory(ctx context.Context, categoryID uint) error {
+	return s.categoryRepo.DeleteCategory(ctx, categoryID)
 }

--- a/internal/services/default/default_category_service_test.go
+++ b/internal/services/default/default_category_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -14,43 +15,44 @@ type MockCategoryRepository struct {
 	mock.Mock
 }
 
-func (m *MockCategoryRepository) CreateCategory(category *models.Category) error {
-	args := m.Called(category)
+func (m *MockCategoryRepository) CreateCategory(ctx context.Context, category *models.Category) error {
+	args := m.Called(ctx, category)
 	return args.Error(0)
 }
 
-func (m *MockCategoryRepository) GetCategoryByID(id uint) (*models.Category, error) {
-	args := m.Called(id)
+func (m *MockCategoryRepository) GetCategoryByID(ctx context.Context, id uint) (*models.Category, error) {
+	args := m.Called(ctx, id)
 	if args.Get(0) != nil {
 		return args.Get(0).(*models.Category), args.Error(1)
 	}
 	return nil, args.Error(1)
 }
 
-func (m *MockCategoryRepository) GetAllCategories() ([]models.Category, error) {
-	args := m.Called()
+func (m *MockCategoryRepository) GetAllCategories(ctx context.Context) ([]models.Category, error) {
+	args := m.Called(ctx)
 	return args.Get(0).([]models.Category), args.Error(1)
 }
 
-func (m *MockCategoryRepository) UpdateCategory(category *models.Category) error {
-	args := m.Called(category)
+func (m *MockCategoryRepository) UpdateCategory(ctx context.Context, category *models.Category) error {
+	args := m.Called(ctx, category)
 	return args.Error(0)
 }
 
-func (m *MockCategoryRepository) DeleteCategory(id uint) error {
-	args := m.Called(id)
+func (m *MockCategoryRepository) DeleteCategory(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
 func TestCreateCategory(t *testing.T) {
 	mockRepo := new(MockCategoryRepository)
 	service := NewCategoryService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Create valid category", func(t *testing.T) {
 		category := &models.Category{Name: "Groceries", Description: "Food and drinks"}
-		mockRepo.On("CreateCategory", category).Return(nil)
+		mockRepo.On("CreateCategory", ctx, category).Return(nil)
 
-		err := service.CreateCategory(category)
+		err := service.CreateCategory(ctx, category)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
@@ -59,6 +61,7 @@ func TestCreateCategory(t *testing.T) {
 func TestGetCategories(t *testing.T) {
 	mockRepo := new(MockCategoryRepository)
 	service := NewCategoryService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Retrieve multiple categories", func(t *testing.T) {
 		mockRepo.ExpectedCalls = nil // Reset expectations
@@ -68,9 +71,9 @@ func TestGetCategories(t *testing.T) {
 			{ID: 2, Name: "Entertainment", Description: "Movies and fun"},
 		}
 
-		mockRepo.On("GetAllCategories").Return(categories, nil)
+		mockRepo.On("GetAllCategories", ctx).Return(categories, nil)
 
-		result, err := service.GetCategories()
+		result, err := service.GetCategories(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, result, 2)
 		mockRepo.AssertExpectations(t)
@@ -79,9 +82,9 @@ func TestGetCategories(t *testing.T) {
 	t.Run("Retrieve categories when none exist", func(t *testing.T) {
 		mockRepo.ExpectedCalls = nil // Reset expectations
 
-		mockRepo.On("GetAllCategories").Return([]models.Category{}, nil)
+		mockRepo.On("GetAllCategories", ctx).Return([]models.Category{}, nil)
 
-		result, err := service.GetCategories()
+		result, err := service.GetCategories(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, result, 0)
 		mockRepo.AssertExpectations(t)
@@ -91,21 +94,22 @@ func TestGetCategories(t *testing.T) {
 func TestUpdateCategory(t *testing.T) {
 	mockRepo := new(MockCategoryRepository)
 	service := NewCategoryService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Update existing category", func(t *testing.T) {
 		category := &models.Category{ID: 1, Name: "Travel", Description: "Flights & hotels"}
-		mockRepo.On("UpdateCategory", category).Return(nil)
+		mockRepo.On("UpdateCategory", ctx, category).Return(nil)
 
-		err := service.UpdateCategory(category)
+		err := service.UpdateCategory(ctx, category)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
 
 	t.Run("Fail to update non-existent category", func(t *testing.T) {
 		category := &models.Category{ID: 9999, Name: "Luxury", Description: "Expensive items"}
-		mockRepo.On("UpdateCategory", category).Return(errors.New("category not found"))
+		mockRepo.On("UpdateCategory", ctx, category).Return(errors.New("category not found"))
 
-		err := service.UpdateCategory(category)
+		err := service.UpdateCategory(ctx, category)
 		assert.Error(t, err)
 		assert.Equal(t, "category not found", err.Error())
 		mockRepo.AssertExpectations(t)
@@ -115,19 +119,20 @@ func TestUpdateCategory(t *testing.T) {
 func TestDeleteCategory(t *testing.T) {
 	mockRepo := new(MockCategoryRepository)
 	service := NewCategoryService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Delete existing category", func(t *testing.T) {
-		mockRepo.On("DeleteCategory", uint(1)).Return(nil)
+		mockRepo.On("DeleteCategory", ctx, uint(1)).Return(nil)
 
-		err := service.DeleteCategory(1)
+		err := service.DeleteCategory(ctx, 1)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
 
 	t.Run("Fail to delete non-existent category", func(t *testing.T) {
-		mockRepo.On("DeleteCategory", uint(9999)).Return(errors.New("category not found"))
+		mockRepo.On("DeleteCategory", ctx, uint(9999)).Return(errors.New("category not found"))
 
-		err := service.DeleteCategory(9999)
+		err := service.DeleteCategory(ctx, 9999)
 		assert.Error(t, err)
 		assert.Equal(t, "category not found", err.Error())
 		mockRepo.AssertExpectations(t)

--- a/internal/services/default/default_payment_method_service.go
+++ b/internal/services/default/default_payment_method_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/repositories"
 )
@@ -14,21 +16,21 @@ func NewPaymentMethodService(paymentMethodRepo repositories.PaymentMethodReposit
 }
 
 // AddPaymentMethod creates a new payment method
-func (s *DefaultPaymentMethodService) AddPaymentMethod(paymentMethod *models.PaymentMethod) error {
-	return s.paymentMethodRepo.CreatePaymentMethod(paymentMethod)
+func (s *DefaultPaymentMethodService) AddPaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error {
+	return s.paymentMethodRepo.CreatePaymentMethod(ctx, paymentMethod)
 }
 
 // GetPaymentMethodsByUser retrieves payment methods by user ID
-func (s *DefaultPaymentMethodService) GetPaymentMethodsByUser(userID uint) ([]models.PaymentMethod, error) {
-	return s.paymentMethodRepo.GetPaymentMethodsByUserID(userID)
+func (s *DefaultPaymentMethodService) GetPaymentMethodsByUser(ctx context.Context, userID uint) ([]models.PaymentMethod, error) {
+	return s.paymentMethodRepo.GetPaymentMethodsByUserID(ctx, userID)
 }
 
 // UpdatePaymentMethod modifies an existing payment method
-func (s *DefaultPaymentMethodService) UpdatePaymentMethod(paymentMethod *models.PaymentMethod) error {
-	return s.paymentMethodRepo.UpdatePaymentMethod(paymentMethod)
+func (s *DefaultPaymentMethodService) UpdatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error {
+	return s.paymentMethodRepo.UpdatePaymentMethod(ctx, paymentMethod)
 }
 
 // DeletePaymentMethod removes a payment method
-func (s *DefaultPaymentMethodService) DeletePaymentMethod(paymentMethodID uint) error {
-	return s.paymentMethodRepo.DeletePaymentMethod(paymentMethodID)
+func (s *DefaultPaymentMethodService) DeletePaymentMethod(ctx context.Context, paymentMethodID uint) error {
+	return s.paymentMethodRepo.DeletePaymentMethod(ctx, paymentMethodID)
 }

--- a/internal/services/default/default_payment_method_service_test.go
+++ b/internal/services/default/default_payment_method_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -14,43 +15,44 @@ type MockPaymentMethodRepository struct {
 	mock.Mock
 }
 
-func (m *MockPaymentMethodRepository) CreatePaymentMethod(paymentMethod *models.PaymentMethod) error {
-	args := m.Called(paymentMethod)
+func (m *MockPaymentMethodRepository) CreatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error {
+	args := m.Called(ctx, paymentMethod)
 	return args.Error(0)
 }
 
-func (m *MockPaymentMethodRepository) GetPaymentMethodByID(id uint) (*models.PaymentMethod, error) {
-	args := m.Called(id)
+func (m *MockPaymentMethodRepository) GetPaymentMethodByID(ctx context.Context, id uint) (*models.PaymentMethod, error) {
+	args := m.Called(ctx, id)
 	if args.Get(0) != nil {
 		return args.Get(0).(*models.PaymentMethod), args.Error(1)
 	}
 	return nil, args.Error(1)
 }
 
-func (m *MockPaymentMethodRepository) GetPaymentMethodsByUserID(userID uint) ([]models.PaymentMethod, error) {
-	args := m.Called(userID)
+func (m *MockPaymentMethodRepository) GetPaymentMethodsByUserID(ctx context.Context, userID uint) ([]models.PaymentMethod, error) {
+	args := m.Called(ctx, userID)
 	return args.Get(0).([]models.PaymentMethod), args.Error(1)
 }
 
-func (m *MockPaymentMethodRepository) UpdatePaymentMethod(paymentMethod *models.PaymentMethod) error {
-	args := m.Called(paymentMethod)
+func (m *MockPaymentMethodRepository) UpdatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error {
+	args := m.Called(ctx, paymentMethod)
 	return args.Error(0)
 }
 
-func (m *MockPaymentMethodRepository) DeletePaymentMethod(id uint) error {
-	args := m.Called(id)
+func (m *MockPaymentMethodRepository) DeletePaymentMethod(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
 func TestAddPaymentMethod(t *testing.T) {
 	mockRepo := new(MockPaymentMethodRepository)
 	service := NewPaymentMethodService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Create valid payment method", func(t *testing.T) {
 		paymentMethod := &models.PaymentMethod{Name: "Credit Card", UserID: 1}
-		mockRepo.On("CreatePaymentMethod", paymentMethod).Return(nil)
+		mockRepo.On("CreatePaymentMethod", ctx, paymentMethod).Return(nil)
 
-		err := service.AddPaymentMethod(paymentMethod)
+		err := service.AddPaymentMethod(ctx, paymentMethod)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
@@ -59,6 +61,7 @@ func TestAddPaymentMethod(t *testing.T) {
 func TestGetPaymentMethodsByUser(t *testing.T) {
 	mockRepo := new(MockPaymentMethodRepository)
 	service := NewPaymentMethodService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Retrieve multiple payment methods", func(t *testing.T) {
 		mockRepo.ExpectedCalls = nil // Reset expectations
@@ -68,9 +71,9 @@ func TestGetPaymentMethodsByUser(t *testing.T) {
 			{ID: 2, Name: "Google Pay", UserID: 1},
 		}
 
-		mockRepo.On("GetPaymentMethodsByUserID", uint(1)).Return(paymentMethods, nil)
+		mockRepo.On("GetPaymentMethodsByUserID", ctx, uint(1)).Return(paymentMethods, nil)
 
-		result, err := service.GetPaymentMethodsByUser(1)
+		result, err := service.GetPaymentMethodsByUser(ctx, 1)
 		assert.NoError(t, err)
 		assert.Len(t, result, 2)
 		mockRepo.AssertExpectations(t)
@@ -79,9 +82,9 @@ func TestGetPaymentMethodsByUser(t *testing.T) {
 	t.Run("Retrieve payment methods when none exist", func(t *testing.T) {
 		mockRepo.ExpectedCalls = nil // Reset expectations
 
-		mockRepo.On("GetPaymentMethodsByUserID", uint(999)).Return([]models.PaymentMethod{}, nil)
+		mockRepo.On("GetPaymentMethodsByUserID", ctx, uint(999)).Return([]models.PaymentMethod{}, nil)
 
-		result, err := service.GetPaymentMethodsByUser(999)
+		result, err := service.GetPaymentMethodsByUser(ctx, 999)
 		assert.NoError(t, err)
 		assert.Len(t, result, 0)
 		mockRepo.AssertExpectations(t)
@@ -91,21 +94,22 @@ func TestGetPaymentMethodsByUser(t *testing.T) {
 func TestUpdatePaymentMethod(t *testing.T) {
 	mockRepo := new(MockPaymentMethodRepository)
 	service := NewPaymentMethodService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Update existing payment method", func(t *testing.T) {
 		paymentMethod := &models.PaymentMethod{ID: 1, Name: "Bank Transfer", UserID: 1}
-		mockRepo.On("UpdatePaymentMethod", paymentMethod).Return(nil)
+		mockRepo.On("UpdatePaymentMethod", ctx, paymentMethod).Return(nil)
 
-		err := service.UpdatePaymentMethod(paymentMethod)
+		err := service.UpdatePaymentMethod(ctx, paymentMethod)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
 
 	t.Run("Fail to update non-existent payment method", func(t *testing.T) {
 		paymentMethod := &models.PaymentMethod{ID: 9999, Name: "Cryptocurrency", UserID: 1}
-		mockRepo.On("UpdatePaymentMethod", paymentMethod).Return(errors.New("payment method not found"))
+		mockRepo.On("UpdatePaymentMethod", ctx, paymentMethod).Return(errors.New("payment method not found"))
 
-		err := service.UpdatePaymentMethod(paymentMethod)
+		err := service.UpdatePaymentMethod(ctx, paymentMethod)
 		assert.Error(t, err)
 		assert.Equal(t, "payment method not found", err.Error())
 		mockRepo.AssertExpectations(t)
@@ -115,19 +119,20 @@ func TestUpdatePaymentMethod(t *testing.T) {
 func TestDeletePaymentMethod(t *testing.T) {
 	mockRepo := new(MockPaymentMethodRepository)
 	service := NewPaymentMethodService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Delete existing payment method", func(t *testing.T) {
-		mockRepo.On("DeletePaymentMethod", uint(1)).Return(nil)
+		mockRepo.On("DeletePaymentMethod", ctx, uint(1)).Return(nil)
 
-		err := service.DeletePaymentMethod(1)
+		err := service.DeletePaymentMethod(ctx, 1)
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
 	})
 
 	t.Run("Fail to delete non-existent payment method", func(t *testing.T) {
-		mockRepo.On("DeletePaymentMethod", uint(9999)).Return(errors.New("payment method not found"))
+		mockRepo.On("DeletePaymentMethod", ctx, uint(9999)).Return(errors.New("payment method not found"))
 
-		err := service.DeletePaymentMethod(9999)
+		err := service.DeletePaymentMethod(ctx, 9999)
 		assert.Error(t, err)
 		assert.Equal(t, "payment method not found", err.Error())
 		mockRepo.AssertExpectations(t)

--- a/internal/services/default/default_transaction_service.go
+++ b/internal/services/default/default_transaction_service.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/apperrors"
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/repositories"
@@ -16,9 +18,9 @@ func NewTransactionService(transactionRepo repositories.TransactionRepository, b
 }
 
 // AddTransaction validates and saves a transaction
-func (s *DefaultTransactionService) AddTransaction(transaction *models.Transaction) error {
+func (s *DefaultTransactionService) AddTransaction(ctx context.Context, transaction *models.Transaction) error {
 	// Check if transaction exceeds budget
-	budgets, err := s.budgetRepo.GetBudgetsByUserID(transaction.UserID)
+	budgets, err := s.budgetRepo.GetBudgetsByUserID(ctx, transaction.UserID)
 	if err != nil {
 		return apperrors.Internal("budget_lookup_failed", "failed to validate transaction budget", err)
 	}
@@ -31,7 +33,7 @@ func (s *DefaultTransactionService) AddTransaction(transaction *models.Transacti
 		}
 	}
 
-	if err := s.transactionRepo.CreateTransaction(transaction); err != nil {
+	if err := s.transactionRepo.CreateTransaction(ctx, transaction); err != nil {
 		return apperrors.Internal("transaction_create_failed", "failed to create transaction", err)
 	}
 
@@ -39,8 +41,8 @@ func (s *DefaultTransactionService) AddTransaction(transaction *models.Transacti
 }
 
 // GetTransactionsByUser retrieves all transactions for a user
-func (s *DefaultTransactionService) GetTransactionsByUser(userID uint) ([]models.Transaction, error) {
-	transactions, err := s.transactionRepo.GetTransactionsByUserID(userID)
+func (s *DefaultTransactionService) GetTransactionsByUser(ctx context.Context, userID uint) ([]models.Transaction, error) {
+	transactions, err := s.transactionRepo.GetTransactionsByUserID(ctx, userID)
 	if err != nil {
 		return nil, apperrors.Internal("transactions_fetch_failed", "failed to retrieve transactions", err)
 	}
@@ -49,8 +51,8 @@ func (s *DefaultTransactionService) GetTransactionsByUser(userID uint) ([]models
 }
 
 // DeleteTransactionForUser removes a transaction that belongs to the authenticated user.
-func (s *DefaultTransactionService) DeleteTransactionForUser(userID, transactionID uint) error {
-	transaction, err := s.transactionRepo.GetTransactionByID(transactionID)
+func (s *DefaultTransactionService) DeleteTransactionForUser(ctx context.Context, userID, transactionID uint) error {
+	transaction, err := s.transactionRepo.GetTransactionByID(ctx, transactionID)
 	if err != nil {
 		return apperrors.NotFound("transaction_not_found", "transaction not found")
 	}
@@ -59,7 +61,7 @@ func (s *DefaultTransactionService) DeleteTransactionForUser(userID, transaction
 		return apperrors.NotFound("transaction_not_found", "transaction not found")
 	}
 
-	if err := s.transactionRepo.DeleteTransaction(transactionID); err != nil {
+	if err := s.transactionRepo.DeleteTransaction(ctx, transactionID); err != nil {
 		return apperrors.Internal("transaction_delete_failed", "failed to delete transaction", err)
 	}
 

--- a/internal/services/default/default_transaction_service_test.go
+++ b/internal/services/default/default_transaction_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -16,31 +17,31 @@ type MockTransactionRepository struct {
 	mock.Mock
 }
 
-func (m *MockTransactionRepository) CreateTransaction(transaction *models.Transaction) error {
-	args := m.Called(transaction)
+func (m *MockTransactionRepository) CreateTransaction(ctx context.Context, transaction *models.Transaction) error {
+	args := m.Called(ctx, transaction)
 	return args.Error(0)
 }
 
-func (m *MockTransactionRepository) GetTransactionByID(id uint) (*models.Transaction, error) {
-	args := m.Called(id)
+func (m *MockTransactionRepository) GetTransactionByID(ctx context.Context, id uint) (*models.Transaction, error) {
+	args := m.Called(ctx, id)
 	if args.Get(0) != nil {
 		return args.Get(0).(*models.Transaction), args.Error(1)
 	}
 	return nil, args.Error(1)
 }
 
-func (m *MockTransactionRepository) GetTransactionsByUserID(userID uint) ([]models.Transaction, error) {
-	args := m.Called(userID)
+func (m *MockTransactionRepository) GetTransactionsByUserID(ctx context.Context, userID uint) ([]models.Transaction, error) {
+	args := m.Called(ctx, userID)
 	return args.Get(0).([]models.Transaction), args.Error(1)
 }
 
-func (m *MockTransactionRepository) UpdateTransaction(transaction *models.Transaction) error {
-	args := m.Called(transaction)
+func (m *MockTransactionRepository) UpdateTransaction(ctx context.Context, transaction *models.Transaction) error {
+	args := m.Called(ctx, transaction)
 	return args.Error(0)
 }
 
-func (m *MockTransactionRepository) DeleteTransaction(id uint) error {
-	args := m.Called(id)
+func (m *MockTransactionRepository) DeleteTransaction(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
 	return args.Error(0)
 }
 
@@ -48,6 +49,7 @@ func TestAddTransaction(t *testing.T) {
 	mockTransactionRepo := new(MockTransactionRepository)
 	mockBudgetRepo := new(MockBudgetRepository)
 	service := NewTransactionService(mockTransactionRepo, mockBudgetRepo)
+	ctx := context.Background()
 
 	t.Run("Create valid transaction", func(t *testing.T) {
 		mockTransactionRepo.ExpectedCalls = nil // Reset expectations
@@ -61,10 +63,10 @@ func TestAddTransaction(t *testing.T) {
 			Date:       time.Now(),
 		}
 
-		mockBudgetRepo.On("GetBudgetsByUserID", uint(1)).Return([]models.Budget{}, nil)
-		mockTransactionRepo.On("CreateTransaction", transaction).Return(nil)
+		mockBudgetRepo.On("GetBudgetsByUserID", ctx, uint(1)).Return([]models.Budget{}, nil)
+		mockTransactionRepo.On("CreateTransaction", ctx, transaction).Return(nil)
 
-		err := service.AddTransaction(transaction)
+		err := service.AddTransaction(ctx, transaction)
 		assert.NoError(t, err)
 		mockTransactionRepo.AssertExpectations(t)
 	})
@@ -85,9 +87,9 @@ func TestAddTransaction(t *testing.T) {
 			{UserID: 1, CategoryID: 2, Limit: 1000.00},
 		}
 
-		mockBudgetRepo.On("GetBudgetsByUserID", uint(1)).Return(budgets, nil)
+		mockBudgetRepo.On("GetBudgetsByUserID", ctx, uint(1)).Return(budgets, nil)
 
-		err := service.AddTransaction(transaction)
+		err := service.AddTransaction(ctx, transaction)
 		assert.Error(t, err)
 		assert.Equal(t, "transaction exceeds budget limit", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindValidation))
@@ -106,9 +108,9 @@ func TestAddTransaction(t *testing.T) {
 		}
 
 		// Simulate an error when retrieving budgets
-		mockBudgetRepo.On("GetBudgetsByUserID", uint(1)).Return([]models.Budget{}, errors.New("database error"))
+		mockBudgetRepo.On("GetBudgetsByUserID", ctx, uint(1)).Return([]models.Budget{}, errors.New("database error"))
 
-		err := service.AddTransaction(transaction)
+		err := service.AddTransaction(ctx, transaction)
 
 		// Ensure the error is returned
 		assert.Error(t, err)
@@ -124,6 +126,7 @@ func TestAddTransaction(t *testing.T) {
 func TestGetTransactionsByUser(t *testing.T) {
 	mockTransactionRepo := new(MockTransactionRepository)
 	service := NewTransactionService(mockTransactionRepo, nil)
+	ctx := context.Background()
 
 	t.Run("Retrieve transactions for user", func(t *testing.T) {
 		transactions := []models.Transaction{
@@ -131,9 +134,9 @@ func TestGetTransactionsByUser(t *testing.T) {
 			{ID: 2, UserID: 1, Type: "income", Amount: 200, CategoryID: 2},
 		}
 
-		mockTransactionRepo.On("GetTransactionsByUserID", uint(1)).Return(transactions, nil)
+		mockTransactionRepo.On("GetTransactionsByUserID", ctx, uint(1)).Return(transactions, nil)
 
-		result, err := service.GetTransactionsByUser(1)
+		result, err := service.GetTransactionsByUser(ctx, 1)
 		assert.NoError(t, err)
 		assert.Len(t, result, 2)
 		mockTransactionRepo.AssertExpectations(t)
@@ -143,20 +146,21 @@ func TestGetTransactionsByUser(t *testing.T) {
 func TestDeleteTransaction(t *testing.T) {
 	mockTransactionRepo := new(MockTransactionRepository)
 	service := NewTransactionService(mockTransactionRepo, nil)
+	ctx := context.Background()
 
 	t.Run("Delete existing transaction", func(t *testing.T) {
-		mockTransactionRepo.On("GetTransactionByID", uint(1)).Return(&models.Transaction{ID: 1, UserID: 1}, nil)
-		mockTransactionRepo.On("DeleteTransaction", uint(1)).Return(nil)
+		mockTransactionRepo.On("GetTransactionByID", ctx, uint(1)).Return(&models.Transaction{ID: 1, UserID: 1}, nil)
+		mockTransactionRepo.On("DeleteTransaction", ctx, uint(1)).Return(nil)
 
-		err := service.DeleteTransactionForUser(1, 1)
+		err := service.DeleteTransactionForUser(ctx, 1, 1)
 		assert.NoError(t, err)
 		mockTransactionRepo.AssertExpectations(t)
 	})
 
 	t.Run("Fail to delete non-existent transaction", func(t *testing.T) {
-		mockTransactionRepo.On("GetTransactionByID", uint(9999)).Return(nil, errors.New("transaction not found"))
+		mockTransactionRepo.On("GetTransactionByID", ctx, uint(9999)).Return(nil, errors.New("transaction not found"))
 
-		err := service.DeleteTransactionForUser(1, 9999)
+		err := service.DeleteTransactionForUser(ctx, 1, 9999)
 		assert.Error(t, err)
 		assert.Equal(t, "transaction not found", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindNotFound))
@@ -164,9 +168,9 @@ func TestDeleteTransaction(t *testing.T) {
 	})
 
 	t.Run("Fail to delete another user's transaction", func(t *testing.T) {
-		mockTransactionRepo.On("GetTransactionByID", uint(2)).Return(&models.Transaction{ID: 2, UserID: 99}, nil)
+		mockTransactionRepo.On("GetTransactionByID", ctx, uint(2)).Return(&models.Transaction{ID: 2, UserID: 99}, nil)
 
-		err := service.DeleteTransactionForUser(1, 2)
+		err := service.DeleteTransactionForUser(ctx, 1, 2)
 		assert.Error(t, err)
 		assert.Equal(t, "transaction not found", err.Error())
 		assert.True(t, isAppErrorKind(err, apperrors.KindNotFound))

--- a/internal/services/default/default_user_service.go
+++ b/internal/services/default/default_user_service.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"strings"
 
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/apperrors"
@@ -18,7 +19,7 @@ func NewUserService(userRepo repositories.UserRepository) *DefaultUserService {
 }
 
 // RegisterUser creates a new user with a hashed password
-func (s *DefaultUserService) RegisterUser(name, email, password string) (*models.User, error) {
+func (s *DefaultUserService) RegisterUser(ctx context.Context, name, email, password string) (*models.User, error) {
 	// Hash password
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {
@@ -27,7 +28,7 @@ func (s *DefaultUserService) RegisterUser(name, email, password string) (*models
 
 	// Create user
 	user := &models.User{Name: name, Email: email, Password: string(hashedPassword)}
-	err = s.userRepo.CreateUser(user)
+	err = s.userRepo.CreateUser(ctx, user)
 	if err != nil {
 		if isUniqueConstraintError(err) {
 			return nil, apperrors.Conflict("email_already_registered", "email already registered")
@@ -39,8 +40,8 @@ func (s *DefaultUserService) RegisterUser(name, email, password string) (*models
 }
 
 // AuthenticateUser checks email & password for login
-func (s *DefaultUserService) AuthenticateUser(email, password string) (*models.User, error) {
-	user, err := s.userRepo.GetUserByEmail(email)
+func (s *DefaultUserService) AuthenticateUser(ctx context.Context, email, password string) (*models.User, error) {
+	user, err := s.userRepo.GetUserByEmail(ctx, email)
 	if err != nil {
 		return nil, apperrors.Unauthorized("invalid_credentials", "invalid credentials")
 	}

--- a/internal/services/default/default_user_service_test.go
+++ b/internal/services/default/default_user_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -16,13 +17,13 @@ type MockUserRepository struct {
 	mock.Mock
 }
 
-func (m *MockUserRepository) CreateUser(user *models.User) error {
-	args := m.Called(user)
+func (m *MockUserRepository) CreateUser(ctx context.Context, user *models.User) error {
+	args := m.Called(ctx, user)
 	return args.Error(0)
 }
 
-func (m *MockUserRepository) GetUserByEmail(email string) (*models.User, error) {
-	args := m.Called(email)
+func (m *MockUserRepository) GetUserByEmail(ctx context.Context, email string) (*models.User, error) {
+	args := m.Called(ctx, email)
 	if args.Get(0) != nil {
 		return args.Get(0).(*models.User), args.Error(1)
 	}
@@ -32,15 +33,16 @@ func (m *MockUserRepository) GetUserByEmail(email string) (*models.User, error) 
 func TestRegisterUser(t *testing.T) {
 	mockRepo := new(MockUserRepository)
 	service := NewUserService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Register valid user", func(t *testing.T) {
-		mockRepo.On("CreateUser", mock.MatchedBy(func(u *models.User) bool {
+		mockRepo.On("CreateUser", ctx, mock.MatchedBy(func(u *models.User) bool {
 			// Check that the password is hashed
 			err := bcrypt.CompareHashAndPassword([]byte(u.Password), []byte("mypassword"))
 			return err == nil
 		})).Return(nil)
 
-		createdUser, err := service.RegisterUser("John Doe", "john@example.com", "mypassword")
+		createdUser, err := service.RegisterUser(ctx, "John Doe", "john@example.com", "mypassword")
 		assert.NoError(t, err)
 		assert.NotNil(t, createdUser)
 		assert.Equal(t, "John Doe", createdUser.Name)
@@ -50,9 +52,9 @@ func TestRegisterUser(t *testing.T) {
 	t.Run("Fail when repository returns an error", func(t *testing.T) {
 		mockRepo.ExpectedCalls = nil // Reset expectations
 
-		mockRepo.On("CreateUser", mock.Anything).Return(errors.New("database error"))
+		mockRepo.On("CreateUser", ctx, mock.Anything).Return(errors.New("database error"))
 
-		createdUser, err := service.RegisterUser("Jane Doe", "jane@example.com", "securepassword")
+		createdUser, err := service.RegisterUser(ctx, "Jane Doe", "jane@example.com", "securepassword")
 
 		// Ensure the error is returned
 		assert.Error(t, err)
@@ -69,7 +71,7 @@ func TestRegisterUser(t *testing.T) {
 		// Create an excessively long password
 		longPassword := string(make([]byte, 1000)) // 1000 bytes long
 
-		createdUser, err := service.RegisterUser("John Doe", "john@example.com", longPassword)
+		createdUser, err := service.RegisterUser(ctx, "John Doe", "john@example.com", longPassword)
 
 		// Ensure bcrypt failure occurs
 		assert.Error(t, err)
@@ -84,15 +86,16 @@ func TestRegisterUser(t *testing.T) {
 func TestAuthenticateUser(t *testing.T) {
 	mockRepo := new(MockUserRepository)
 	service := NewUserService(mockRepo)
+	ctx := context.Background()
 
 	t.Run("Authenticate valid user", func(t *testing.T) {
 		hashedPassword, err := bcrypt.GenerateFromPassword([]byte("mypassword"), bcrypt.DefaultCost)
 		assert.NoError(t, err)
 		user := &models.User{Name: "John Doe", Email: "john@example.com", Password: string(hashedPassword)}
 
-		mockRepo.On("GetUserByEmail", "john@example.com").Return(user, nil)
+		mockRepo.On("GetUserByEmail", ctx, "john@example.com").Return(user, nil)
 
-		authenticatedUser, err := service.AuthenticateUser("john@example.com", "mypassword")
+		authenticatedUser, err := service.AuthenticateUser(ctx, "john@example.com", "mypassword")
 		assert.NoError(t, err)
 		assert.NotNil(t, authenticatedUser)
 		assert.Equal(t, "John Doe", authenticatedUser.Name)
@@ -100,9 +103,9 @@ func TestAuthenticateUser(t *testing.T) {
 	})
 
 	t.Run("Fail when user does not exist", func(t *testing.T) {
-		mockRepo.On("GetUserByEmail", "nonexistent@example.com").Return(nil, errors.New("not found"))
+		mockRepo.On("GetUserByEmail", ctx, "nonexistent@example.com").Return(nil, errors.New("not found"))
 
-		authenticatedUser, err := service.AuthenticateUser("nonexistent@example.com", "password")
+		authenticatedUser, err := service.AuthenticateUser(ctx, "nonexistent@example.com", "password")
 		assert.Error(t, err)
 		assert.Nil(t, authenticatedUser)
 		assert.Equal(t, "invalid credentials", err.Error())
@@ -114,9 +117,9 @@ func TestAuthenticateUser(t *testing.T) {
 		assert.NoError(t, err)
 		user := &models.User{Name: "John Doe", Email: "john@example.com", Password: string(hashedPassword)}
 
-		mockRepo.On("GetUserByEmail", "john@example.com").Return(user, nil)
+		mockRepo.On("GetUserByEmail", ctx, "john@example.com").Return(user, nil)
 
-		authenticatedUser, err := service.AuthenticateUser("john@example.com", "wrongpassword")
+		authenticatedUser, err := service.AuthenticateUser(ctx, "john@example.com", "wrongpassword")
 		assert.Error(t, err)
 		assert.Nil(t, authenticatedUser)
 		assert.Equal(t, "invalid credentials", err.Error())

--- a/internal/services/payment_method_service.go
+++ b/internal/services/payment_method_service.go
@@ -1,13 +1,15 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // PaymentMethodService defines the interface for payment method operations
 type PaymentMethodService interface {
-	AddPaymentMethod(paymentMethod *models.PaymentMethod) error
-	GetPaymentMethodsByUser(userID uint) ([]models.PaymentMethod, error)
-	UpdatePaymentMethod(paymentMethod *models.PaymentMethod) error
-	DeletePaymentMethod(paymentMethodID uint) error
+	AddPaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error
+	GetPaymentMethodsByUser(ctx context.Context, userID uint) ([]models.PaymentMethod, error)
+	UpdatePaymentMethod(ctx context.Context, paymentMethod *models.PaymentMethod) error
+	DeletePaymentMethod(ctx context.Context, paymentMethodID uint) error
 }

--- a/internal/services/transaction_service.go
+++ b/internal/services/transaction_service.go
@@ -1,12 +1,14 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // TransactionService defines the interface for transaction operations
 type TransactionService interface {
-	AddTransaction(transaction *models.Transaction) error
-	GetTransactionsByUser(userID uint) ([]models.Transaction, error)
-	DeleteTransactionForUser(userID, transactionID uint) error
+	AddTransaction(ctx context.Context, transaction *models.Transaction) error
+	GetTransactionsByUser(ctx context.Context, userID uint) ([]models.Transaction, error)
+	DeleteTransactionForUser(ctx context.Context, userID, transactionID uint) error
 }

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -1,11 +1,13 @@
 package services
 
 import (
+	"context"
+
 	"github.com/TsonasIoannis/go-personal-finance-tracker/internal/models"
 )
 
 // UserService defines the interface for user operations
 type UserService interface {
-	RegisterUser(name, email, password string) (*models.User, error)
-	AuthenticateUser(email, password string) (*models.User, error)
+	RegisterUser(ctx context.Context, name, email, password string) (*models.User, error)
+	AuthenticateUser(ctx context.Context, email, password string) (*models.User, error)
 }


### PR DESCRIPTION
Before this refactor, the request could die at the HTTP layer, but the service call and DB query might still keep running in the background because nothing below Gin knew the request was canceled. With the new flow, the controller passes c.Request.Context() into the service, and the repository uses db.WithContext(ctx), so if the a client closes the app, loses signal, or a server timeout hits, the database work can be canceled too.